### PR TITLE
refactor!: remove PendingTask protocol

### DIFF
--- a/Wendy/Classes/Extensions/_PendingTask+Extensions.swift
+++ b/Wendy/Classes/Extensions/_PendingTask+Extensions.swift
@@ -1,13 +1,6 @@
 import Foundation
 
 internal extension PendingTask {
-    mutating func populate(from: PersistedPendingTask) {
-        taskId = from.id
-        dataId = from.dataId
-        groupId = from.groupId
-        createdAt = from.createdAt!
-    }
-
     // Using instead of Equatable protocol because Swift does not allow a protocol inherit another protocol *and* I don't want the subclass to inherit Equatable, I just want to internally.
     func equals(_ other: PendingTask) -> Bool {
         return tag == other.tag &&

--- a/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
+++ b/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
@@ -10,7 +10,7 @@ internal extension PersistedPendingTask {
 
     var pendingTask: PendingTask {
         var blankPendingTask = Wendy.shared.pendingTasksFactory.getTask(tag: self.tag!)
-        blankPendingTask.populate(from: self)
+        blankPendingTask.from(persistedPendingTask: self)
         return blankPendingTask
     }
 

--- a/Wendy/Classes/Factory/PendingTasksFactory.swift
+++ b/Wendy/Classes/Factory/PendingTasksFactory.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public protocol PendingTasksFactory {
-    func getTask(tag: PendingTask.Tag) -> PendingTask
+    func getTask(tag: String) -> PendingTask
 }

--- a/Wendy/Classes/PendingTask.swift
+++ b/Wendy/Classes/PendingTask.swift
@@ -1,21 +1,17 @@
 import Foundation
 
-public protocol PendingTask {
-    typealias Tag = String
-
-    static var tag: Tag { get }
-
-    var taskId: Double? { get set } // Simply links a PendingTask to a PersistedPendingTask. This identifies a PendingTask. It is *not* used as the sort order for when tasks will be run.
-    var dataId: String? { get set }
-    var groupId: String? { get set }
-    var createdAt: Date? { get set } // How the order is determined by the task runner. Just like taskId, this is nil until the PendingTask is added to Wendy.
-
-    func runTask(complete: @escaping (Error?) -> Void)
-    func isReadyToRun() -> Bool
-}
-
-public extension PendingTask {
-    var tag: Tag {
-        return Self.tag
+public struct PendingTask {
+    let tag: String
+    let taskId: Double? // populated later
+    let dataId: String?
+    let groupId: String?
+    let createdAt: Date? // populated later
+    
+    internal static func nonPersisted(tag: String, dataId: String?, groupId: String?) -> PendingTask {
+        return PendingTask(tag: tag, taskId: nil, dataId: dataId, groupId: groupId, createdAt: nil)
+    }
+    
+    internal func from(persistedPendingTask: PersistedPendingTask) -> PendingTask {
+        return PendingTask(tag: self.tag, taskId: persistedPendingTask.id, dataId: self.dataId, groupId: self.groupId, createdAt: persistedPendingTask.createdAt)
     }
 }

--- a/Wendy/Classes/Type/ReasonPendingTaskSkipped.swift
+++ b/Wendy/Classes/Type/ReasonPendingTaskSkipped.swift
@@ -4,6 +4,5 @@ import Foundation
  Tasks that were skipped and will run again at some time in the future.
  */
 public enum ReasonPendingTaskSkipped {
-    case notReadyToRun
     case partOfFailedGroup
 }

--- a/Wendy/Classes/Wendy.swift
+++ b/Wendy/Classes/Wendy.swift
@@ -35,8 +35,10 @@ public class Wendy {
 
         return WendyUIBackgroundFetchResult(taskRunnerResult: runAllTasksResult, backgroundFetchResult: runAllTasksResult.backgroundFetchResult)
     }
-
-    public final func addTask(_ pendingTaskToAdd: PendingTask) -> Double {
+    
+    public final func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
+        let pendingTaskToAdd = PendingTask.nonPersisted(tag: tag, dataId: dataId, groupId: groupId)
+        
         _ = pendingTasksFactory.getTask(tag: pendingTaskToAdd.tag) // Asserts that you didn't forget to add your PendingTask to the factory. Might as well check for it now while instead of when it's too late!
 
         // We enforce a best practice here.


### PR DESCRIPTION
The code base uses PendingTask as a data structure. I felt that it still made sense to use it as a data structure to represent a task so I modified the protocol to a struct.

---

**Stack**:
- #81
- #80
- #79
- #77
- #78 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*