### PR TITLE
refactor: remove PendingTasksFactory

### DIFF
--- a/Wendy/Classes/DB/Manager/PendingTasksManager.swift
+++ b/Wendy/Classes/DB/Manager/PendingTasksManager.swift
@@ -64,7 +64,6 @@ internal class PendingTasksManager {
 
     internal func getAllTasks() -> [PendingTask] {
         let viewContext = CoreDataManager.shared.viewContext
-        let pendingTaskFactory = Wendy.shared.pendingTasksFactory
 
         do {
             let persistedPendingTasks: [PersistedPendingTask] = try viewContext.fetch(PersistedPendingTask.fetchRequest()) as [PersistedPendingTask]

--- a/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
+++ b/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
@@ -9,9 +9,7 @@ internal extension PersistedPendingTask {
     }
 
     var pendingTask: PendingTask {
-        var blankPendingTask = Wendy.shared.pendingTasksFactory.getTask(tag: self.tag!)
-        blankPendingTask.from(persistedPendingTask: self)
-        return blankPendingTask
+        return PendingTask.persisted(self)
     }
 
     convenience init(pendingTask: PendingTask) {

--- a/Wendy/Classes/Factory/PendingTasksFactory.swift
+++ b/Wendy/Classes/Factory/PendingTasksFactory.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public protocol PendingTasksFactory {
-    func getTask(tag: String) -> PendingTask
-}

--- a/Wendy/Classes/PendingTask.swift
+++ b/Wendy/Classes/PendingTask.swift
@@ -11,6 +11,10 @@ public struct PendingTask {
         return PendingTask(tag: tag, taskId: nil, dataId: dataId, groupId: groupId, createdAt: nil)
     }
     
+    internal static func persisted(_ persistedPendingTask: PersistedPendingTask) -> PendingTask {
+        return PendingTask(tag: persistedPendingTask.tag!, taskId: persistedPendingTask.id, dataId: persistedPendingTask.dataId, groupId: persistedPendingTask.groupId, createdAt: persistedPendingTask.createdAt)
+    }
+    
     internal func from(persistedPendingTask: PersistedPendingTask) -> PendingTask {
         return PendingTask(tag: self.tag, taskId: persistedPendingTask.id, dataId: self.dataId, groupId: self.groupId, createdAt: persistedPendingTask.createdAt)
     }

--- a/Wendy/Classes/Wendy.swift
+++ b/Wendy/Classes/Wendy.swift
@@ -3,20 +3,10 @@ import Foundation
 public class Wendy {
     public static var shared: Wendy = Wendy()
 
-    // Setup this way to (1) be a less buggy way of making sure that the developer remembers to call setup() to populate pendingTasksFactory.
-    private var initPendingTasksFactory: PendingTasksFactory?
-    internal lazy var pendingTasksFactory: PendingTasksFactory = {
-        guard let pendingTasksFactory = self.initPendingTasksFactory else {
-            fatalError("You forgot to setup Wendy via Wendy.setup()")
-        }
-        return pendingTasksFactory
-    }()
-
     private init() {}
 
-    public class func setup(tasksFactory: PendingTasksFactory, debug: Bool = false) {
+    public class func setup(debug: Bool = false) {
         WendyConfig.debug = debug
-        Wendy.shared.pendingTasksFactory = tasksFactory
     }
 
     /**
@@ -38,8 +28,6 @@ public class Wendy {
     
     public final func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
         let pendingTaskToAdd = PendingTask.nonPersisted(tag: tag, dataId: dataId, groupId: groupId)
-        
-        _ = pendingTasksFactory.getTask(tag: pendingTaskToAdd.tag) // Asserts that you didn't forget to add your PendingTask to the factory. Might as well check for it now while instead of when it's too late!
 
         // We enforce a best practice here.
         if let similarTask = PendingTasksManager.shared.getRandomTaskForTag(pendingTaskToAdd.tag) {


### PR DESCRIPTION
We are changing the way that tasks are executed by Wendy. 1 function will be called in a user's app to run tasks. The factory no longer adds value if we are going to call this 1 function.

---

**Stack**:
- #83
- #82
- #81
- #80
- #79 ⬅
- #77


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*