### PR TITLE
refactor: create generic queue writer to allow writing to different d…

### DIFF
--- a/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
+++ b/Wendy/Classes/Extensions/_PersistedPendingTask+Extension.swift
@@ -9,7 +9,7 @@ internal extension PersistedPendingTask {
     }
 
     var pendingTask: PendingTask {
-        return PendingTask.persisted(self)
+        return PendingTask.from(persistedPendingTask: self)
     }
 
     convenience init(pendingTask: PendingTask) {
@@ -17,6 +17,16 @@ internal extension PersistedPendingTask {
         self.dataId = pendingTask.dataId
         self.groupId = pendingTask.groupId
         self.tag = pendingTask.tag
+        self.createdAt = Date() // Very important. This determines the sort order of when tasks run by the task runner. createdAt needs to be set by Wendy internally and only modified by Wendy under certain circumstances.
+
+        self.id = PendingTasksUtil.getNextPendingTaskId()
+    }
+    
+    convenience init(tag: String, dataId: String?, groupId: String?) {
+        self.init()
+        self.dataId = dataId
+        self.groupId = groupId
+        self.tag = tag
         self.createdAt = Date() // Very important. This determines the sort order of when tasks run by the task runner. createdAt needs to be set by Wendy internally and only modified by Wendy under certain circumstances.
 
         self.id = PendingTasksUtil.getNextPendingTaskId()

--- a/Wendy/Classes/PendingTask.swift
+++ b/Wendy/Classes/PendingTask.swift
@@ -7,16 +7,8 @@ public struct PendingTask {
     public let groupId: String?
     public let createdAt: Date? // populated later
     
-    internal static func nonPersisted(tag: String, dataId: String?, groupId: String?) -> PendingTask {
-        return PendingTask(tag: tag, taskId: nil, dataId: dataId, groupId: groupId, createdAt: nil)
-    }
-    
-    internal static func persisted(_ persistedPendingTask: PersistedPendingTask) -> PendingTask {
+    internal static func from(persistedPendingTask: PersistedPendingTask) -> PendingTask {
         return PendingTask(tag: persistedPendingTask.tag!, taskId: persistedPendingTask.id, dataId: persistedPendingTask.dataId, groupId: persistedPendingTask.groupId, createdAt: persistedPendingTask.createdAt)
-    }
-    
-    internal func from(persistedPendingTask: PersistedPendingTask) -> PendingTask {
-        return PendingTask(tag: self.tag, taskId: persistedPendingTask.id, dataId: self.dataId, groupId: self.groupId, createdAt: persistedPendingTask.createdAt)
     }
         
     public init(tag: String, taskId: Double?, dataId: String?, groupId: String?, createdAt: Date?) {

--- a/Wendy/Classes/PendingTasksRunner.swift
+++ b/Wendy/Classes/PendingTasksRunner.swift
@@ -55,7 +55,7 @@ internal class PendingTasksRunner {
 
             if !PendingTasksUtil.isTaskValid(taskId: taskId) {
                 LogUtil.d("Task: \(taskToRun.describe()) is cancelled. Deleting the task.")
-                PendingTasksManager.shared.deleteTask(taskId)
+                PendingTasksManager.shared.delete(taskId: taskId)
                 runTaskResult = TaskRunResult.cancelled
                 WendyConfig.logTaskComplete(taskToRun, successful: true, cancelled: true)
 
@@ -88,7 +88,7 @@ internal class PendingTasksRunner {
                     PendingTasksManager.shared.updatePlaceInLine(taskToRun.taskId!, createdAt: PendingTasksUtil.getRerunCurrentlyRunningPendingTaskTime()!)
                 } else {
                     LogUtil.d("Deleting task: \(taskToRun.describe()).")
-                    PendingTasksManager.shared.deleteTask(taskId)
+                    PendingTasksManager.shared.delete(taskId: taskId)
                 }
                 PendingTasksUtil.resetRerunCurrentlyRunningPendingTask()
 

--- a/Wendy/Classes/QueueWriter.swift
+++ b/Wendy/Classes/QueueWriter.swift
@@ -1,0 +1,19 @@
+//
+//  QueueWriter.swift
+//  Wendy
+//
+//  Created by Levi Bostian on 1/24/24.
+//
+
+import Foundation
+
+public protocol QueueWriter {
+    func add(tag: String, dataId: String?, groupId: String?) -> PendingTask
+    func delete(taskId: Double) -> Bool
+}
+
+public extension QueueWriter {
+    func delete(task: PendingTask) -> Bool {
+        return delete(taskId: task.taskId!)
+    }
+}

--- a/Wendy/Classes/Wendy.swift
+++ b/Wendy/Classes/Wendy.swift
@@ -34,16 +34,13 @@ public class Wendy {
     }
     
     public final func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
-        // TODO: we give the parameters to the Writer directly. No need to create a non-persisted version of PendingTask.
-        let pendingTaskToAdd = PendingTask.nonPersisted(tag: tag, dataId: dataId, groupId: groupId)
+        let addedTask = PendingTasksManager.shared.add(tag: tag, dataId: dataId, groupId: groupId)
 
-        let addedPendingTask: PendingTask = PendingTasksManager.shared.insertPendingTask(pendingTaskToAdd)
+        WendyConfig.logNewTaskAdded(addedTask)
 
-        WendyConfig.logNewTaskAdded(pendingTaskToAdd)
+        try runTaskAutomaticallyIfAbleTo(addedTask)
 
-        try runTaskAutomaticallyIfAbleTo(addedPendingTask)
-
-        return addedPendingTask.taskId!
+        return addedTask.taskId!
     }
 
     /**


### PR DESCRIPTION
…ata sources

This allows us to make Wendy more flexible to users where they can choose how to save the SDK data. The main purpose, however, is part of the migration away from CoreData.

commit-id:9206d5a7