### PR TITLE
test: create integration tests for fs reader/writer

### DIFF
--- a/Example/Tests/Store/FileSystemQueueIntegrationTest.swift
+++ b/Example/Tests/Store/FileSystemQueueIntegrationTest.swift
@@ -1,0 +1,51 @@
+//
+//  FileSystemQueueIntegrationTest.swift
+//  Wendy_Tests
+//
+//  Created by Levi Bostian on 2/4/24.
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import Wendy
+import XCTest
+
+class FileSystemQueueIntegrationTest: XCTestCase {
+    private var reader: FileSystemQueueReader!
+    private var writer: FileSystemQueueWriter!
+    
+    override func setUp() {
+        super.setUp()
+        
+        FileSystemQueueImpl.reset()
+        deleteAllFileSystemFiles()
+        deleteKeyValueStore() 
+
+        reader = FileSystemQueueReader()
+        writer = FileSystemQueueWriter()
+    }
+    
+    // MARK: simple reading and writing
+    
+    func test_givenNoTasks_expectReadEmptyList() {
+        let actual = reader.getAllTasks()
+        
+        XCTAssertTrue(actual.isEmpty)
+    }
+    
+    func test_getTaskById_givenNoTaskWithId_expectNil() {
+        let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
+        XCTAssertNil(reader.getTaskByTaskId(2))
+        XCTAssertNotNil(reader.getTaskByTaskId(1))
+    }
+    
+    func test_givenDeleteTask_expectTaskGotDeleted() {
+        let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
+        
+        XCTAssertNotNil(reader.getTaskByTaskId(1))
+        
+        let _ = writer.delete(taskId: 1)
+        
+        XCTAssertNil(reader.getTaskByTaskId(1))
+    }
+}

--- a/Example/Tests/TestHelpers.swift
+++ b/Example/Tests/TestHelpers.swift
@@ -1,0 +1,36 @@
+//
+//  TestHelpers.swift
+//  Wendy_Tests
+//
+//  Created by Levi Bostian on 2/4/24.
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+extension String {
+    static var random: String {
+        UUID().uuidString
+    }
+}
+
+extension XCTest {
+    func deleteAllFileSystemFiles() {
+        let fileManager = FileManager.default
+        let documentsUrl = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        guard let fileUrls = try? fileManager.contentsOfDirectory(at: documentsUrl, includingPropertiesForKeys: nil, options: []) else {
+            return
+        }
+        for fileUrl in fileUrls {
+            try? fileManager.removeItem(at: fileUrl)
+        }
+    }
+    
+    func deleteKeyValueStore() {
+        let userDefaults = UserDefaults.standard
+        for key in userDefaults.dictionaryRepresentation().keys {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+}

--- a/Example/Wendy.xcodeproj/project.pbxproj
+++ b/Example/Wendy.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		F70C72C72B5416D6002A5560 /* MyWendyTaskRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70C72C62B5416D6002A5560 /* MyWendyTaskRunner.swift */; };
 		F70C72CA2B541746002A5560 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70C72C92B541746002A5560 /* Errors.swift */; };
 		F70C72CC2B54179A002A5560 /* TaskTags.swift in Sources */ = {isa = PBXBuildFile; fileRef = F70C72CB2B54179A002A5560 /* TaskTags.swift */; };
+		F71471602B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F714715F2B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift */; };
+		F71471622B6FC52300AE8E78 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F71471612B6FC52300AE8E78 /* TestHelpers.swift */; };
 		F73E96E9206EE7B400E7306F /* PendingTaskTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F73E96E8206EE7B400E7306F /* PendingTaskTableViewCell.swift */; };
 		F76AFB662086738A001A427B /* Pods_Wendy_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 66F6204D5DD1D3F56DFF7D6D /* Pods_Wendy_Example.framework */; };
 		F787F16123AEB034007EA1CE /* PendingTasksRunnerResultTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F787F16023AEB034007EA1CE /* PendingTasksRunnerResultTest.swift */; };
@@ -63,6 +65,8 @@
 		F70C72C62B5416D6002A5560 /* MyWendyTaskRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWendyTaskRunner.swift; sourceTree = "<group>"; };
 		F70C72C92B541746002A5560 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		F70C72CB2B54179A002A5560 /* TaskTags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskTags.swift; sourceTree = "<group>"; };
+		F714715F2B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSystemQueueIntegrationTest.swift; sourceTree = "<group>"; };
+		F71471612B6FC52300AE8E78 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		F73E96E8206EE7B400E7306F /* PendingTaskTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTaskTableViewCell.swift; sourceTree = "<group>"; };
 		F787F16023AEB034007EA1CE /* PendingTasksRunnerResultTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTasksRunnerResultTest.swift; sourceTree = "<group>"; };
 		F787F16223AEB672007EA1CE /* ErrorForTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorForTesting.swift; sourceTree = "<group>"; };
@@ -165,9 +169,11 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F714715E2B6FC42300AE8E78 /* Store */,
 				F787F15F23AEB00E007EA1CE /* Type */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				F787F16223AEB672007EA1CE /* ErrorForTesting.swift */,
+				F71471612B6FC52300AE8E78 /* TestHelpers.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -215,6 +221,14 @@
 				F70C72CB2B54179A002A5560 /* TaskTags.swift */,
 			);
 			path = Type;
+			sourceTree = "<group>";
+		};
+		F714715E2B6FC42300AE8E78 /* Store */ = {
+			isa = PBXGroup;
+			children = (
+				F714715F2B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift */,
+			);
+			path = Store;
 			sourceTree = "<group>";
 		};
 		F73E96E7206EE79700E7306F /* UITableViewCell */ = {
@@ -462,6 +476,8 @@
 				F7B34B9D23B1814F002F355A /* WendyUIBackgroundFetchResult+TestingTests.swift in Sources */,
 				F787F16323AEB672007EA1CE /* ErrorForTesting.swift in Sources */,
 				F7B34B9923B17E98002F355A /* PendingTasksRunnerResult+TestingTests.swift in Sources */,
+				F71471602B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift in Sources */,
+				F71471622B6FC52300AE8E78 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Wendy/Classes/Store/FileSystem/FileSystemQueue.swift
+++ b/Wendy/Classes/Store/FileSystem/FileSystemQueue.swift
@@ -18,7 +18,11 @@ internal protocol FileSystemQueue {
 
 internal class FileSystemQueueImpl: FileSystemQueue {
     
-    internal static let shared = FileSystemQueueImpl()
+    internal static var shared = FileSystemQueueImpl()
+    
+    internal static func reset() { // for tests
+        Self.shared = FileSystemQueueImpl()
+    }
     
     private let fileStore: FileSystemStore = FileManagerFileSystemStore()
     private let queueFilePath: [String] = ["tasks_queue.json"]


### PR DESCRIPTION
Includes simple tests to make sure the reader and writer are successfully reading and writing files.

We are not testing all of the functions inside of the reader and writer. Some functions would be better to test in a separate integration test when the FS reader/writer is running in the rest of the codebase.

commit-id:a4869e2c