### PR TITLE
feat: add public function to add a queue reader

### DIFF
--- a/Wendy/Classes/DB/Manager/PendingTasksManager.swift
+++ b/Wendy/Classes/DB/Manager/PendingTasksManager.swift
@@ -4,6 +4,8 @@ import UIKit
 
 internal class PendingTasksManager: QueueReader, QueueWriter {
     internal static let shared: PendingTasksManager = PendingTasksManager()
+    
+    private var queueReaders: [QueueReader] = []
 
     private init() {}
 
@@ -121,4 +123,9 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
 
         return keyValues
     }
+    
+    public func addQueueReader(_ queueReader: QueueReader) {
+        queueReaders.append(queueReader)
+    }
+    
 }

--- a/Wendy/Classes/Wendy.swift
+++ b/Wendy/Classes/Wendy.swift
@@ -151,6 +151,10 @@ public class Wendy {
         }
     }
     
+    public func addQueueReader(_ reader: QueueReader) {
+        PendingTasksManager.shared.addQueueReader(reader)
+    }
+    
     struct InitializedData {
         let taskRunner: WendyTaskRunner
     }


### PR DESCRIPTION
This is part of the coredata migration work by moving the coredata logic into a separate SDK and allow you to add a read-only reader to Wendy to read old pending tasks added in previous versions of Wendy.

In the future, this could be a feature where you could add a reader and a writer. The scope for now is only adding a reader.

---

**Stack**:
- #98
- #97 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*