### PR TITLE
refactor: read pending tasks from multiple queue reader instances

### DIFF
--- a/Example/Tests/PendingTasksManagerTests.swift
+++ b/Example/Tests/PendingTasksManagerTests.swift
@@ -1,0 +1,102 @@
+//
+//  PendingTasksManagerTests.swift
+//  Wendy_Tests
+//
+//  Created by Levi Bostian on 2/9/24.
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Wendy
+
+class PendingTasksManagerTest: XCTestCase {
+    
+    private var queueReader: QueueReaderStub!
+    private var queueReader2: QueueReaderStub!
+        
+    private var pendingTasksManager: PendingTasksManager {
+        PendingTasksManager.shared
+    }
+        
+        override func setUp() {
+            super.setUp()
+
+            queueReader = QueueReaderStub()
+            queueReader2 = QueueReaderStub()
+            
+            PendingTasksManager.initForTesting(queueReaders: [queueReader, queueReader2])
+        }
+    
+    // MARK: getAllTasks
+    
+    func test_getAllTasks_givenNoTasks_expectEmptyList() {
+        queueReader.allTasks = []
+        queueReader2.allTasks = []
+        
+        let actual = pendingTasksManager.getAllTasks()
+        
+        XCTAssertTrue(actual.isEmpty)
+    }
+    
+    func test_getAllTasks_expectTasksSorted() {
+        let givenOldestTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
+        let givenMiddleTask = PendingTask(tag: "bar", taskId: 2, dataId: nil, groupId: nil, createdAt: Date().addingTimeInterval(1))
+        let givenNewestTask = PendingTask(tag: "baz", taskId: 3, dataId: nil, groupId: nil, createdAt: Date().addingTimeInterval(2))
+        
+        queueReader.allTasks = [givenMiddleTask]
+        queueReader2.allTasks = [givenNewestTask, givenOldestTask]
+        
+        let actual = pendingTasksManager.getAllTasks()
+        
+        XCTAssertEqual(actual[0].taskId, 1)
+        XCTAssertEqual(actual[1].taskId, 2)
+        XCTAssertEqual(actual[2].taskId, 3)
+    }
+    
+    // MARK: getTaskByTaskId
+    
+    func test_getTaskByTaskId_givenTaskExists_expectTask() {
+        let givenTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
+        let givenTaskWithDifferentId = PendingTask(tag: "foo", taskId: 2, dataId: nil, groupId: nil, createdAt: Date())
+        
+        queueReader.allTasks = [givenTask]
+        queueReader2.allTasks = [givenTaskWithDifferentId]
+        
+        let actual = pendingTasksManager.getTaskByTaskId(1)
+        
+        XCTAssertEqual(actual?.taskId, givenTask.taskId)
+    }
+    
+    func test_getTaskByTaskId_givenTaskDoesNotExist_expectNil() {
+        queueReader.allTasks = [PendingTask(tag: "foo", taskId: 2, dataId: nil, groupId: nil, createdAt: Date())]
+        queueReader2.allTasks = [PendingTask(tag: "foo", taskId: 3, dataId: nil, groupId: nil, createdAt: Date())]
+        
+        let actual = pendingTasksManager.getTaskByTaskId(1)
+        
+        XCTAssertNil(actual)
+    }
+    
+    // MARK: getNextTaskToRun
+    
+    func test_getNextTaskToRun_givenNoTasks_expectNil() {
+        queueReader.allTasks = []
+        queueReader2.allTasks = []
+        
+        let actual = pendingTasksManager.getNextTaskToRun(1, filter: nil)
+        
+        XCTAssertNil(actual)
+    }
+    
+    func test_getNextTaskToRun_givenTaskInMultipleReaders_expectGetTask() {
+        let givenTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
+        
+        queueReader.allTasks = []
+        queueReader2.allTasks = [givenTask]
+        
+        let actual = pendingTasksManager.getNextTaskToRun(1, filter: nil)
+        
+        XCTAssertEqual(actual?.tag, "foo")
+    }
+    
+}

--- a/Example/Tests/Store/QueueReaderStub.swift
+++ b/Example/Tests/Store/QueueReaderStub.swift
@@ -1,0 +1,26 @@
+//
+//  QueueReaderStub.swift
+//  Wendy_Tests
+//
+//  Created by Levi Bostian on 2/9/24.
+//  Copyright © 2024 CocoaPods. All rights reserved.
+//
+
+import Foundation
+@testable import Wendy
+
+class QueueReaderStub: QueueReader {
+    var allTasks: [PendingTask] = []
+    
+    func getAllTasks() -> [PendingTask] {
+        allTasks
+    }
+    
+    func getTaskByTaskId(_ taskId: Double) -> PendingTask? {
+        allTasks.first { $0.taskId == taskId }
+    }
+    
+    func getNextTaskToRun(_ lastSuccessfulOrFailedTaskId: Double, filter: RunAllTasksFilter?) -> PendingTask? {
+        allTasks.first
+    }
+}

--- a/Example/Wendy.xcodeproj/project.pbxproj
+++ b/Example/Wendy.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		F7B45F1C206E983F00BC547D /* Wendy.podspec in Resources */ = {isa = PBXBuildFile; fileRef = F7B45F1B206E983F00BC547D /* Wendy.podspec */; };
 		F7E45BA82086697B00CEC32B /* Wendy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E45BA72086697B00CEC32B /* Wendy.framework */; };
 		F7F01444206AF59F00896E9B /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7F01445206AF59F00896E9B /* SnapKit.framework */; };
+		F7FDAD8A2B76575600DA7D56 /* PendingTasksManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FDAD892B76575600DA7D56 /* PendingTasksManagerTests.swift */; };
+		F7FDAD8C2B765AD900DA7D56 /* QueueReaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7FDAD8B2B765AD900DA7D56 /* QueueReaderStub.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +82,8 @@
 		F7E45BA52086697B00CEC32B /* Pods_Wendy_iOS_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_Wendy_iOS_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7E45BA72086697B00CEC32B /* Wendy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Wendy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7F01445206AF59F00896E9B /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7FDAD892B76575600DA7D56 /* PendingTasksManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTasksManagerTests.swift; sourceTree = "<group>"; };
+		F7FDAD8B2B765AD900DA7D56 /* QueueReaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueReaderStub.swift; sourceTree = "<group>"; };
 		F8E5425B4B841F6DAC94C636 /* Pods_Wendy_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Wendy_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -174,6 +178,7 @@
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 				F787F16223AEB672007EA1CE /* ErrorForTesting.swift */,
 				F71471612B6FC52300AE8E78 /* TestHelpers.swift */,
+				F7FDAD892B76575600DA7D56 /* PendingTasksManagerTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -227,6 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				F714715F2B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift */,
+				F7FDAD8B2B765AD900DA7D56 /* QueueReaderStub.swift */,
 			);
 			path = Store;
 			sourceTree = "<group>";
@@ -474,9 +480,11 @@
 			files = (
 				F787F16123AEB034007EA1CE /* PendingTasksRunnerResultTest.swift in Sources */,
 				F7B34B9D23B1814F002F355A /* WendyUIBackgroundFetchResult+TestingTests.swift in Sources */,
+				F7FDAD8A2B76575600DA7D56 /* PendingTasksManagerTests.swift in Sources */,
 				F787F16323AEB672007EA1CE /* ErrorForTesting.swift in Sources */,
 				F7B34B9923B17E98002F355A /* PendingTasksRunnerResult+TestingTests.swift in Sources */,
 				F71471602B6FC44700AE8E78 /* FileSystemQueueIntegrationTest.swift in Sources */,
+				F7FDAD8C2B765AD900DA7D56 /* QueueReaderStub.swift in Sources */,
 				F71471622B6FC52300AE8E78 /* TestHelpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Wendy/Classes/DB/Manager/PendingTasksManager.swift
+++ b/Wendy/Classes/DB/Manager/PendingTasksManager.swift
@@ -3,11 +3,22 @@ import Foundation
 import UIKit
 
 internal class PendingTasksManager: QueueReader, QueueWriter {
-    internal static let shared: PendingTasksManager = PendingTasksManager()
+    internal static var shared: PendingTasksManager = PendingTasksManager()
+    
+    private let coreDataReader = WendyCoreDataQueueReader()
     
     private var queueReaders: [QueueReader] = []
+    
+    internal static func initForTesting(queueReaders: [QueueReader]) {
+        shared = PendingTasksManager()
+        shared.queueReaders = queueReaders
+    }
 
-    private init() {}
+    // singleton constructor
+    private init() {
+        // Set the default, production readers and writers
+        queueReaders.append(coreDataReader)
+    }
 
     func add(tag: String, dataId: String?, groupId: String?) -> PendingTask {
         if tag.isEmpty { Fatal.preconditionFailure("You need to set a unique tag for \(String(describing: PendingTask.self)) instances.") }
@@ -22,44 +33,13 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     }
 
     internal func getAllTasks() -> [PendingTask] {
-        let viewContext = CoreDataManager.shared.viewContext
-
-        do {
-            let persistedPendingTasks: [PersistedPendingTask] = try viewContext.fetch(PersistedPendingTask.fetchRequest()) as [PersistedPendingTask]
-
-            var pendingTasks: [PendingTask] = []
-            persistedPendingTasks.forEach { persistedPendingTask in
-                pendingTasks.append(persistedPendingTask.pendingTask)
-            }
-
-            return pendingTasks
-        } catch let error as NSError {
-            Fatal.error("Error in Wendy while fetching data from database.", error: error)
-            return []
-        }
-    }
-
-    private func getPersistedTaskByTaskId(_ taskId: Double) -> PersistedPendingTask? {
-        let context = CoreDataManager.shared.viewContext
-
-        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
-        pendingTaskFetchRequest.predicate = NSPredicate(format: "id == %f", taskId)
-
-        do {
-            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
-            return pendingTasks.first
-        } catch let error as NSError {
-            Fatal.error("Error in Wendy while fetching data from database.", error: error)
-            return nil
-        }
+        return queueReaders.flatMap { return $0.getAllTasks() }
+            .filter { return $0.createdAt != nil }
+            .sorted(by: { $0.createdAt! < $1.createdAt! })
     }
 
     internal func getTaskByTaskId(_ taskId: Double) -> PendingTask? {
-        guard let persistedPendingTask = getPersistedTaskByTaskId(taskId) else {
-            return nil
-        }
-
-        return persistedPendingTask.pendingTask
+        return queueReaders.compactMap { return $0.getTaskByTaskId(taskId) }.first
     }
 
     // Note: Make sure to keep the query at "delete this table item by ID _____".
@@ -67,7 +47,7 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     func delete(taskId: Double) -> Bool {
         let context = CoreDataManager.shared.viewContext
         
-        guard let persistedPendingTask = getPersistedTaskByTaskId(taskId) else {
+        guard let persistedPendingTask = coreDataReader.getPersistedTaskByTaskId(taskId) else {
             return false
         }
     
@@ -78,7 +58,7 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     }
 
     internal func updatePlaceInLine(_ taskId: Double, createdAt: Date) {
-        guard let persistedPendingTask = getPersistedTaskByTaskId(taskId) else {
+        guard let persistedPendingTask = coreDataReader.getPersistedTaskByTaskId(taskId) else {
             return
         }
 
@@ -88,40 +68,9 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     }
 
     internal func getNextTaskToRun(_ lastSuccessfulOrFailedTaskId: Double, filter: RunAllTasksFilter?) -> PendingTask? {
-        let context = CoreDataManager.shared.viewContext
-
-        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
-
-        var keyValues = ["id > %@": lastSuccessfulOrFailedTaskId as NSObject, "manuallyRun = %@": NSNumber(value: false) as NSObject]
-        if let filter = filter {
-            keyValues = applyFilterPredicates(filter, to: keyValues)
-        }
-
-        let predicates = keyValues.map { NSPredicate(format: $0.key, $0.value) }
-        pendingTaskFetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
-        pendingTaskFetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(PersistedPendingTask.createdAt), ascending: true)]
-
-        do {
-            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
-            if pendingTasks.isEmpty { return nil }
-            let persistedPendingTask: PersistedPendingTask = pendingTasks[0]
-
-            return persistedPendingTask.pendingTask
-        } catch let error as NSError {
-            Fatal.error("Error in Wendy while fetching data from database.", error: error)
-            return nil
-        }
-    }
-
-    private func applyFilterPredicates(_ filter: RunAllTasksFilter, to keyValues: [String: NSObject]) -> [String: NSObject] {
-        var keyValues = keyValues
-
-        switch filter {
-        case .group(let groupId):
-            keyValues["groupId = %@"] = groupId as NSObject
-        }
-
-        return keyValues
+        return queueReaders.compactMap { reader in
+            return reader.getNextTaskToRun(lastSuccessfulOrFailedTaskId, filter: filter)
+        }.first
     }
     
     public func addQueueReader(_ queueReader: QueueReader) {

--- a/Wendy/Classes/DB/Manager/PendingTasksManager.swift
+++ b/Wendy/Classes/DB/Manager/PendingTasksManager.swift
@@ -4,6 +4,8 @@ import UIKit
 
 internal class PendingTasksManager: QueueReader, QueueWriter {
     internal static let shared: PendingTasksManager = PendingTasksManager()
+    
+    private var queueReaders: [QueueReader] = []
 
     private init() {}
 
@@ -121,4 +123,9 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
 
         return keyValues
     }
+    
+    public func addQueueReader(_ queueReader: QueueReader) {
+        queueReaders.append(queueReader)
+    }
+    
 }

--- a/Wendy/Classes/Store/CoreData/CoreDataQueueReader.swift
+++ b/Wendy/Classes/Store/CoreData/CoreDataQueueReader.swift
@@ -1,0 +1,224 @@
+import CoreData
+import Foundation
+import UIKit
+import Wendy
+
+public class WendyCoreDataQueueReader: QueueReader {
+    public init() {}
+
+    internal func insertPendingTask(_ task: PendingTask) -> PendingTask {
+        if task.tag.isEmpty { Fatal.preconditionFailure("You need to set a unique tag for \(String(describing: PendingTask.self)) instances.") }
+
+        let persistedPendingTask: PersistedPendingTask = PersistedPendingTask(pendingTask: task)
+        CoreDataManager.shared.saveContext()
+
+        let pendingTaskForPersistedPendingTask = persistedPendingTask.pendingTask
+
+        return pendingTaskForPersistedPendingTask
+    }
+
+    /**
+     * fatal error if task by taskId does not exist.
+     * fatal error if task by taskId does not belong to any groups.
+     */
+    internal func isTaskFirstTaskOfGroup(_ taskId: Double) -> Bool {
+        guard let persistedPendingTask: PersistedPendingTask = getPersistedTaskByTaskId(taskId) else {
+            fatalError("Task with id: \(taskId) does not exist.")
+        }
+        
+        if persistedPendingTask.groupId == nil {
+            Fatal.preconditionFailure("Task: \(persistedPendingTask.pendingTask.describe()) does not belong to a group.")
+        }
+
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+        pendingTaskFetchRequest.predicate = NSPredicate(format: "groupId == %@", persistedPendingTask.groupId!)
+        pendingTaskFetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(PersistedPendingTask.createdAt), ascending: true)]
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return pendingTasks.first!.id == taskId
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return false
+        }
+    }
+
+    internal func getRandomTaskForTag(_ tag: String) -> PendingTask? {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+        pendingTaskFetchRequest.predicate = NSPredicate(format: "(tag == %@)", tag)
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return pendingTasks.first?.pendingTask
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return nil
+        }
+    }
+
+    public func getAllTasks() -> [PendingTask] {
+        let viewContext = CoreDataManager.shared.viewContext
+
+        do {
+            let persistedPendingTasks: [PersistedPendingTask] = try viewContext.fetch(PersistedPendingTask.fetchRequest()) as [PersistedPendingTask]
+
+            var pendingTasks: [PendingTask] = []
+            persistedPendingTasks.forEach { persistedPendingTask in
+                pendingTasks.append(persistedPendingTask.pendingTask)
+            }
+
+            return pendingTasks
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return []
+        }
+    }
+
+    internal func getExistingTasks(_ task: PendingTask) -> [PendingTask]? {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+
+        var keyValues = ["tag = %@": task.tag as NSObject]
+        if let groupId = task.groupId {
+            keyValues["groupId = %@"] = groupId as NSObject
+        }
+        if let dataId = task.dataId {
+            keyValues["dataId = %@"] = dataId as NSObject
+        }
+
+        let predicates = keyValues.map { NSPredicate(format: $0.key, $0.value) }
+        pendingTaskFetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        pendingTaskFetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(PersistedPendingTask.createdAt), ascending: true)]
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return (pendingTasks.isEmpty) ? nil : pendingTasks.map { $0.pendingTask }
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return nil
+        }
+    }
+
+    internal func getPersistedTaskByTaskId(_ taskId: Double) -> PersistedPendingTask? {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+        pendingTaskFetchRequest.predicate = NSPredicate(format: "id == %f", taskId)
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return pendingTasks.first
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return nil
+        }
+    }
+
+    public func getTaskByTaskId(_ taskId: Double) -> PendingTask? {
+        guard let persistedPendingTask = getPersistedTaskByTaskId(taskId) else {
+            return nil
+        }
+
+        return persistedPendingTask.pendingTask
+    }
+
+    // Note: Make sure to keep the query at "delete this table item by ID _____".
+    // Because of this scenario: The runner is running a task with ID 1. While the task is running a user decides to update that data. This results in having to run that PendingTask a 2nd time (if the running task is successful) to sync the newest changes. To assert this 2nd change, we take advantage of SQLite's unique constraint. On unique constraint collision we replace (update) the data in the database which results in all the PendingTask data being the same except for the ID being incremented. So, after the runner runs the task successfully and wants to delete the task here, it will not delete the task because the ID no longer exists. It has been incremented so the newest changes can be run.
+    internal func deleteTask(_ taskId: Double) {
+        let context = CoreDataManager.shared.viewContext
+        if let persistedPendingTask = getPersistedTaskByTaskId(taskId) {
+            context.delete(persistedPendingTask)
+            CoreDataManager.shared.saveContext()
+        }
+    }
+
+    internal func updatePlaceInLine(_ taskId: Double, createdAt: Date) {
+        guard let persistedPendingTask = getPersistedTaskByTaskId(taskId) else {
+            return
+        }
+
+        let context = CoreDataManager.shared.viewContext
+        persistedPendingTask.setValue(createdAt, forKey: "createdAt")
+        CoreDataManager.shared.saveContext()
+    }
+
+    internal func getTotalNumberOfTasksForRunnerToRun(filter: RunAllTasksFilter?) -> Int {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+
+        var keyValues = ["manuallyRun = %@": NSNumber(value: false) as NSObject]
+        if let filter = filter {
+            keyValues = applyFilterPredicates(filter, to: keyValues)
+        }
+
+        let predicates = keyValues.map { NSPredicate(format: $0.key, $0.value) }
+        pendingTaskFetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return pendingTasks.count
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return 0
+        }
+    }
+
+    internal func getLastPendingTaskInGroup(_ groupId: String) -> PendingTask? {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+        pendingTaskFetchRequest.predicate = NSPredicate(format: "groupId == %@", groupId)
+        pendingTaskFetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(PersistedPendingTask.createdAt), ascending: false)]
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            return pendingTasks.first.map { $0.pendingTask }
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return nil
+        }
+    }
+
+    public func getNextTaskToRun(_ lastSuccessfulOrFailedTaskId: Double, filter: RunAllTasksFilter?) -> PendingTask? {
+        let context = CoreDataManager.shared.viewContext
+
+        let pendingTaskFetchRequest: NSFetchRequest<PersistedPendingTask> = PersistedPendingTask.fetchRequest()
+
+        var keyValues = ["id > %@": lastSuccessfulOrFailedTaskId as NSObject, "manuallyRun = %@": NSNumber(value: false) as NSObject]
+        if let filter = filter {
+            keyValues = applyFilterPredicates(filter, to: keyValues)
+        }
+
+        let predicates = keyValues.map { NSPredicate(format: $0.key, $0.value) }
+        pendingTaskFetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        pendingTaskFetchRequest.sortDescriptors = [NSSortDescriptor(key: #keyPath(PersistedPendingTask.createdAt), ascending: true)]
+
+        do {
+            let pendingTasks: [PersistedPendingTask] = try context.fetch(pendingTaskFetchRequest)
+            if pendingTasks.isEmpty { return nil }
+            let persistedPendingTask: PersistedPendingTask = pendingTasks[0]
+
+            return persistedPendingTask.pendingTask
+        } catch let error as NSError {
+            Fatal.error("Error in Wendy while fetching data from database.", error: error)
+            return nil
+        }
+    }
+
+    private func applyFilterPredicates(_ filter: RunAllTasksFilter, to keyValues: [String: NSObject]) -> [String: NSObject] {
+        var keyValues = keyValues
+
+        switch filter {
+        case .group(let groupId):
+            keyValues["groupId = %@"] = groupId as NSObject
+        }
+
+        return keyValues
+    }
+}

--- a/Wendy/Classes/Wendy.swift
+++ b/Wendy/Classes/Wendy.swift
@@ -151,6 +151,10 @@ public class Wendy {
         }
     }
     
+    public func addQueueReader(_ reader: QueueReader) {
+        PendingTasksManager.shared.addQueueReader(reader)
+    }
+    
     struct InitializedData {
         let taskRunner: WendyTaskRunner
     }


### PR DESCRIPTION
The PendingTasksManager is the 1 class that interacts with queue readers and writer instances. This commit modifies the manager to be able to read tasks from multiple readers.

The code that reads from coredata has been moved out of pendingtasksmanager and into it's own queureader subclass. The logic has not changed for reading from CoreData, just moved from 1 file to another.

commit-id:0c9ff87d

---

**Stack**:
- #98 ⬅
- #97


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*