### PR TITLE
feat!: save new tasks to the file system instead of coredata

### DIFF
--- a/Wendy/Classes/DB/Manager/PendingTasksManager.swift
+++ b/Wendy/Classes/DB/Manager/PendingTasksManager.swift
@@ -3,9 +3,11 @@ import Foundation
 import UIKit
 
 internal class PendingTasksManager: QueueReader, QueueWriter {
+
     internal static var shared: PendingTasksManager = PendingTasksManager()
     
     private let coreDataReader = WendyCoreDataQueueReader()
+    private let queueWriter = FileSystemQueueWriter()
     
     private var queueReaders: [QueueReader] = []
     
@@ -21,15 +23,7 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     }
 
     func add(tag: String, dataId: String?, groupId: String?) -> PendingTask {
-        if tag.isEmpty { Fatal.preconditionFailure("You need to set a unique tag for \(String(describing: PendingTask.self)) instances.") }
-
-        let persistedPendingTask: PersistedPendingTask = PersistedPendingTask(tag: tag, dataId: dataId, groupId: groupId)
-        CoreDataManager.shared.saveContext()
-
-        let pendingTaskForPersistedPendingTask = persistedPendingTask.pendingTask
-        LogUtil.d("Successfully added task to Wendy. Task: \(pendingTaskForPersistedPendingTask.describe())")
-
-        return PendingTask.from(persistedPendingTask: persistedPendingTask)
+        return queueWriter.add(tag: tag, dataId: dataId, groupId: groupId)
     }
 
     internal func getAllTasks() -> [PendingTask] {
@@ -45,26 +39,7 @@ internal class PendingTasksManager: QueueReader, QueueWriter {
     // Note: Make sure to keep the query at "delete this table item by ID _____".
     // Because of this scenario: The runner is running a task with ID 1. While the task is running a user decides to update that data. This results in having to run that PendingTask a 2nd time (if the running task is successful) to sync the newest changes. To assert this 2nd change, we take advantage of SQLite's unique constraint. On unique constraint collision we replace (update) the data in the database which results in all the PendingTask data being the same except for the ID being incremented. So, after the runner runs the task successfully and wants to delete the task here, it will not delete the task because the ID no longer exists. It has been incremented so the newest changes can be run.
     func delete(taskId: Double) -> Bool {
-        let context = CoreDataManager.shared.viewContext
-        
-        guard let persistedPendingTask = coreDataReader.getPersistedTaskByTaskId(taskId) else {
-            return false
-        }
-    
-        context.delete(persistedPendingTask)
-        CoreDataManager.shared.saveContext()
-        
-        return true
-    }
-
-    internal func updatePlaceInLine(_ taskId: Double, createdAt: Date) {
-        guard let persistedPendingTask = coreDataReader.getPersistedTaskByTaskId(taskId) else {
-            return
-        }
-
-        let context = CoreDataManager.shared.viewContext
-        persistedPendingTask.setValue(createdAt, forKey: "createdAt")
-        CoreDataManager.shared.saveContext()
+        return queueWriter.delete(taskId: taskId)
     }
 
     internal func getNextTaskToRun(_ lastSuccessfulOrFailedTaskId: Double, filter: RunAllTasksFilter?) -> PendingTask? {

--- a/Wendy/Classes/PendingTasksRunner.swift
+++ b/Wendy/Classes/PendingTasksRunner.swift
@@ -63,7 +63,6 @@ internal class PendingTasksRunner {
                 return runTaskResult // This code should *not* be executed because of .leave() above.
             }
 
-            PendingTasksUtil.resetRerunCurrentlyRunningPendingTask()
             PendingTasksRunner.shared.currentlyRunningTask = taskToRun
 
             WendyConfig.logTaskRunning(taskToRun)
@@ -83,14 +82,8 @@ internal class PendingTasksRunner {
                 }
 
                 LogUtil.d("Task: \(taskToRun.describe()) ran successful.")
-                if PendingTasksUtil.rerunCurrentlyRunningPendingTask {
-                    LogUtil.d("Task: \(taskToRun.describe()) is set to re-run. Not deleting it.")
-                    PendingTasksManager.shared.updatePlaceInLine(taskToRun.taskId!, createdAt: PendingTasksUtil.getRerunCurrentlyRunningPendingTaskTime()!)
-                } else {
-                    LogUtil.d("Deleting task: \(taskToRun.describe()).")
-                    PendingTasksManager.shared.delete(taskId: taskId)
-                }
-                PendingTasksUtil.resetRerunCurrentlyRunningPendingTask()
+                LogUtil.d("Deleting task: \(taskToRun.describe()).")
+                PendingTasksManager.shared.delete(taskId: taskId)
 
                 WendyConfig.logTaskComplete(taskToRun, successful: successful, cancelled: false)
 

--- a/Wendy/Classes/Util/PendingTasksUtil.swift
+++ b/Wendy/Classes/Util/PendingTasksUtil.swift
@@ -3,7 +3,6 @@ import Foundation
 internal class PendingTasksUtil {
     private static let prefix = "pendingTasks_"
     private static let pendingTasksNextPendingTaskIdKey = "\(prefix)pendingTasksNextPendingTaskIdKey"
-    private static let rerunCurrentlyRunningPendingTaskKey = "\(prefix)rerunCurrentlyRunningPendingTaskKey"
     // Tasks with id >= validPendingTasksIdThreshold are valid. < are invalid.
     private static let validPendingTasksIdThresholdKey = "\(prefix)validPendingTasksIdThresholdKey"
 
@@ -27,31 +26,5 @@ internal class PendingTasksUtil {
 
     internal class func setValidPendingTasksIdThreshold() {
         UserDefaults.standard.set(currentPendingTaskId + 1, forKey: validPendingTasksIdThresholdKey)
-    }
-
-    internal static var rerunCurrentlyRunningPendingTask: Bool {
-        get {
-            return UserDefaults.standard.double(forKey: rerunCurrentlyRunningPendingTaskKey) > 0
-        }
-        set {
-            if newValue {
-                UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: rerunCurrentlyRunningPendingTaskKey)
-            } else {
-                UserDefaults.standard.set(0, forKey: rerunCurrentlyRunningPendingTaskKey)
-            }
-        }
-    }
-
-    internal class func getRerunCurrentlyRunningPendingTaskTime() -> Date? {
-        let timeInternal = UserDefaults.standard.double(forKey: rerunCurrentlyRunningPendingTaskKey)
-        guard timeInternal > 0 else {
-            return nil
-        }
-
-        return Date(timeIntervalSince1970: timeInternal)
-    }
-
-    internal class func resetRerunCurrentlyRunningPendingTask() {
-        rerunCurrentlyRunningPendingTask = false
     }
 }


### PR DESCRIPTION
As part of the migration from coredata to the file system, the code that performs write operations has been swapped from writing to coredata to writing to the file system.

For existing users of Wendy, you can still run tasks currently saved to coredata, but it will require code changes to  your app by installing a separate dependency. All coredata code is being deleted from the wendy codebase in the same release as this commit.

---

**Stack**:
- #101
- #100
- #99 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*