### PR TITLE
ci: upload code coverage to coveralls.io for analysis

### DIFF
--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -1,0 +1,30 @@
+
+# Can only run on push events, not pull requests.
+# PRs on github generate weird branch names that semantic-release does not support. 
+on: [push]
+
+concurrency: # cancel previous workflow run if one exists. 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+jobs:
+  deployment:
+    runs-on: macos-13 # because cocoapods is already installed on these machines
+    permissions:
+      contents: write # to set permissions for semantic-release dry-run to pass 
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: setup git user to run semantic-release
+      run: |
+        git config --global user.email "user@example.com"
+        git config --global user.name "Example User"
+
+    - uses: ./.github/actions/setup-semantic-release
+    
+    - name: Run semantic-release in dry run
+      run: unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.ref_name }},main"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [pull_request]
 
 concurrency: # cancel previous workflow run if one exists. 
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -29,23 +29,10 @@ jobs:
     
     - run: task test
     - run: task coverage
-
-  deployment:
-    runs-on: macos-13 # because cocoapods is already installed on these machines
-    permissions:
-      contents: write # to set permissions for semantic-release dry-run to pass 
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: setup git user to run semantic-release
-      run: |
-        git config --global user.email "user@example.com"
-        git config --global user.name "Example User"
-
-    - uses: ./.github/actions/setup-semantic-release
-    
-    - name: Run semantic-release in dry run
-      run: unset GITHUB_ACTIONS && npx semantic-release --dry-run --no-ci --branches "${{ github.ref_name }},main"
+    - name: Upload coverage for analysis 
+      uses: coverallsapp/github-action@v2
+      with: 
+        file: .build/lcov.info
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        # try and speedup the action by homebrew not having to do more then it needs when installing the coveralls tool 
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,7 +18,8 @@ tasks:
   test:
     cmds:
       - task: clean
-      - xcodebuild -scheme Wendy -destination 'platform=iOS Simulator,name=iPhone 15' -derivedDataPath .build/derivedData -resultBundlePath './Wendy.xcresult' -enableCodeCoverage YES test | xcbeautify
+      - xcodebuild -scheme Wendy -destination 'platform=iOS Simulator,name=iPhone 15' -derivedDataPath .build/derivedData -enableCodeCoverage YES build-for-testing | xcbeautify
+      - xcodebuild -scheme Wendy -destination 'platform=iOS Simulator,name=iPhone 15' -derivedDataPath .build/derivedData -enableCodeCoverage YES test-without-building | xcbeautify
   
   # Resourced used to create this command:
   # https://github.com/michaelhenry/swifty-code-coverage/
@@ -26,6 +27,6 @@ tasks:
     preconditions:
       - test -d .build/
     cmds:
-      - xcrun llvm-cov export "$(find .build -name WendyTests.xctest | tail -n1)/WendyTests" -format=lcov -instr-profile=$(find .build -name *.profdata | tail -n1) > .build/lcov.info
-      - xcrun llvm-cov report "$(find .build -name WendyTests.xctest | tail -n1)/WendyTests"  -instr-profile=$(find .build -name *.profdata | tail -n1) -use-color
+      - xcrun llvm-cov export "$(find .build -name WendyTests.xctest | tail -n1)/WendyTests" -instr-profile=$(find .build -name *.profdata | tail -n1) -ignore-filename-regex=Tests/* -format=lcov > .build/lcov.info
+      - xcrun llvm-cov report "$(find .build -name WendyTests.xctest | tail -n1)/WendyTests" -instr-profile=$(find .build -name *.profdata | tail -n1) -ignore-filename-regex=Tests/* -use-color
   


### PR DESCRIPTION
Coveralls is a tool that can make the code coverage reports actionable. Especially in PRs where it will say how coverage will be effected if PR is merged.

commit-id:2c98f6a3