### PR TITLE
ci: upload code coverage reports on main for PR comparisons

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,7 @@
-on: [pull_request]
+on: 
+  pull_request:
+  push:
+    branches: [main]
 
 concurrency: # cancel previous workflow run if one exists. 
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Without having code coverage reports uploaded on main branch, we have nothing to compare to in PRs.

commit-id:2dca999a