### PR TITLE
refactor: add all dependencies into the digraph

### DIFF
--- a/Source/DIGraph.swift
+++ b/Source/DIGraph.swift
@@ -10,11 +10,13 @@ import Foundation
 public class DIGraph {
     
     public static let shared = DIGraph()
+    
+    let mutex = Mutex()
 
     private init() {}
 
     public var overrides: [String: Any] = [:]
-    public var singletons: [String: Any] = [:]
+    internal var singletons: [String: Any] = [:]
 
     /**
      Reset graph. Meant to be used in `tearDown()` of tests.

--- a/Source/PendingTasksRunner.swift
+++ b/Source/PendingTasksRunner.swift
@@ -14,6 +14,12 @@ internal class PendingTasksRunner {
     private var lastSuccessfulOrFailedTaskId: Double = 0
     private var failedTasksGroups: [String] = []
     internal var currentlyRunningTask: PendingTask?
+    
+    private let pendingTasksManager: PendingTasksManager
+    
+    init(pendingTasksManager: PendingTasksManager) {
+        self.pendingTasksManager = pendingTasksManager
+    }
 
     // I created a separate class for running a single pending task simply as a wrapper to the function runPendingTask(taskId).
     // this function is very important to have it run in a synchronized way and to enforce that, I need to make sure it uses a DispatchQueue to run all of it's callers requests. So, I created this class to make sure I don't make the mistake of accidently calling this `runPendingTask(taskId)` function inside of the `PendingTasksRunner` without following my rule of *this function must run in a synchonized way!* (I already made this mistake....)
@@ -22,6 +28,9 @@ internal class PendingTasksRunner {
         
         private var pendingTasksRunner: PendingTasksRunner {
             DIGraph.shared.pendingTasksRunner
+        }
+        private var pendingTasksManager: PendingTasksManager {
+            DIGraph.shared.pendingTasksManager
         }
 
         private let runPendingTaskDispatchQueue = DispatchQueue(label: "com.levibostian.wendy.PendingTasksRunner.Scheduler.runPendingTask")
@@ -49,7 +58,7 @@ internal class PendingTasksRunner {
             runTaskDispatchGroup.enter()
             var runTaskResult: TaskRunResult!
 
-            guard let taskToRun = PendingTasksManager.shared.getTaskByTaskId(taskId) else {
+            guard let taskToRun = pendingTasksManager.getTaskByTaskId(taskId) else {
                 runTaskResult = TaskRunResult.cancelled
 
                 runTaskDispatchGroup.leave()
@@ -58,7 +67,7 @@ internal class PendingTasksRunner {
 
             if !PendingTasksUtil.isTaskValid(taskId: taskId) {
                 LogUtil.d("Task: \(taskToRun.describe()) is cancelled. Deleting the task.")
-                PendingTasksManager.shared.delete(taskId: taskId)
+                pendingTasksManager.delete(taskId: taskId)
                 runTaskResult = TaskRunResult.cancelled
                 WendyConfig.logTaskComplete(taskToRun, successful: true, cancelled: true)
 
@@ -86,7 +95,7 @@ internal class PendingTasksRunner {
 
                 LogUtil.d("Task: \(taskToRun.describe()) ran successful.")
                 LogUtil.d("Deleting task: \(taskToRun.describe()).")
-                PendingTasksManager.shared.delete(taskId: taskId)
+                self.pendingTasksManager.delete(taskId: taskId)
 
                 WendyConfig.logTaskComplete(taskToRun, successful: successful, cancelled: false)
 
@@ -111,7 +120,7 @@ internal class PendingTasksRunner {
     internal func runAllTasks(filter: RunAllTasksFilter?, result: PendingTasksRunnerResult = PendingTasksRunnerResult.new()) -> PendingTasksRunnerResult {
         LogUtil.d("Getting next task to run.")
 
-        guard let nextTaskToRun = PendingTasksManager.shared.getNextTaskToRun(lastSuccessfulOrFailedTaskId, filter: filter) else {
+        guard let nextTaskToRun = pendingTasksManager.getNextTaskToRun(lastSuccessfulOrFailedTaskId, filter: filter) else {
             LogUtil.d("All done running tasks.")
             WendyConfig.logAllTasksComplete()
 
@@ -136,7 +145,7 @@ internal class PendingTasksRunner {
                 failedTasksGroups.append(taskGroupId)
             }
             return runAllTasks(filter: filter, result: result.addResult(jobRunResult))
-        case .skipped(let reason):
+        case .skipped(_):
             return runAllTasks(filter: filter, result: result.addResult(jobRunResult))
         }
     }

--- a/Source/Store/FileSystem/FileSystemQueue.swift
+++ b/Source/Store/FileSystem/FileSystemQueue.swift
@@ -16,21 +16,21 @@ internal protocol FileSystemQueue {
     func delete(_ taskId: Double)
 }
 
+// sourcery: InjectRegister = "FileSystemQueue"
+// sourcery: InjectSingleton
 internal class FileSystemQueueImpl: FileSystemQueue {
-    
-    internal static var shared = FileSystemQueueImpl()
-    
-    internal static func reset() { // for tests
-        Self.shared = FileSystemQueueImpl()
-    }
-    
-    private let fileStore: FileSystemStore = FileManagerFileSystemStore()
+        
+    private let fileStore: FileSystemStore
     private let queueFilePath: [String] = ["tasks_queue.json"]
     
     private let mutex = Mutex()
     
     private var hasLoadedCache = false
     private var cache: [PendingTask] = []
+    
+    init(fileStore: FileSystemStore) {
+        self.fileStore = fileStore
+    }
     
     func load() {
         mutex.lock()

--- a/Source/Store/FileSystem/FileSystemQueueReader.swift
+++ b/Source/Store/FileSystem/FileSystemQueueReader.swift
@@ -7,10 +7,14 @@
 
 import Foundation
 
+// sourcery: InjectRegister = "QueueReader"
+// sourcery: InjectSingleton
 public class FileSystemQueueReader: QueueReader {
     
-    private var queue: FileSystemQueue {
-        return FileSystemQueueImpl.shared
+    private let queue: FileSystemQueue
+    
+    init(queue: FileSystemQueue) {
+        self.queue = queue
     }
     
     public func getAllTasks() -> [PendingTask] {

--- a/Source/Store/FileSystem/FileSystemQueueWriter.swift
+++ b/Source/Store/FileSystem/FileSystemQueueWriter.swift
@@ -7,23 +7,16 @@
 
 import Foundation
 
-// Note: This class is currently not being used in the codebase. After all filesystem code is written, it can be hooked up to the rest of Wendy to enable it.
-
 // A writer, that stores data in the form of files on the file system.
+// sourcery: InjectRegister = "QueueWriter"
+// sourcery: InjectSingleton
 public class FileSystemQueueWriter: QueueWriter {
-    
-    @Atomic public private(set) static var shared = FileSystemQueueWriter()
-    
-    internal static func reset() { // for tests
-        Self.shared = FileSystemQueueWriter()
-    }
-    
+        
     private let mutex = Mutex()
+    private let queue: FileSystemQueue
     
-    private init() {}
-
-    private var queue: FileSystemQueue {
-        return FileSystemQueueImpl.shared
+    init(queue: FileSystemQueue) {
+        self.queue = queue
     }
     
     public func add(tag: String, dataId: String?, groupId: String?) -> PendingTask {

--- a/Source/Store/FileSystem/FileSystemStore.swift
+++ b/Source/Store/FileSystem/FileSystemStore.swift
@@ -10,11 +10,13 @@ import Foundation
 // Abstraction around iOS FileManager framework to allow mocking and easier to use API.
 internal protocol FileSystemStore {
     // filePath array will be joined into a string where each array item is a directory. Last item in array is the file name.
+    @discardableResult
     func saveFile(_ data: Data, filePath: [String]) -> Bool
     // Returns nil if file does not exist.
     func readFile(_ filePath: [String]) -> Data?
 }
 
+// sourcery: InjectRegister = "FileSystemStore"
 internal class FileManagerFileSystemStore: FileSystemStore {
 
     // This class makes sure that all files created in SDK are in the same directory

--- a/Source/Templates/AutoDependencyInjection.stencil
+++ b/Source/Templates/AutoDependencyInjection.stencil
@@ -73,7 +73,6 @@ DIGraph().reset()
 extension DIGraph {
     // call in automated test suite to confirm that all dependnecies able to resolve and not cause runtime exceptions. 
     // internal scope so each module can provide their own version of the function with the same name. 
-    @available(iOSApplicationExtension, unavailable) // some properties could be unavailable to app extensions so this function must also. 
     internal func testDependenciesAbleToResolve() -> Int {
         var countDependenciesResolved = 0
 
@@ -96,18 +95,22 @@ extension DIGraph {
     // {{ class }} (singleton)
     {% call overrideGetterProperty class dep false true %}
     {% call addPropertyWrappers dep %}
-    {{ dep.accessLevel }} var shared{{ class }}: {{ class }} {
-        // Use a DispatchQueue to make singleton thread safe. You must create unique dispatchqueues instead of using 1 shared one or you will get a crash when trying 
-        // to call DispatchQueue.sync{} while already inside another DispatchQueue.sync{} call. 
-        return DispatchQueue(label: "DIGraph_{{class}}_singleton_access").sync {
-            let existingSingletonInstance = self.singletons[String(describing: {{ class }}.self)] as? {{ class }}
-            let instance = existingSingletonInstance ?? _get_{{ class|lowerFirstLetter }}()
-            self.singletons[String(describing: {{ class }}.self)] = instance
-            return instance    
+    private var shared{{ class }}: {{ class }} {
+        mutex.lock()
+        
+        if let existingSingleton = singletons[String(describing: {{ class }}.self)] as? {{ class }} {
+            mutex.unlock()
+            return existingSingleton
         }
+        
+        let newInstance = new{{ class }}
+        singletons[String(describing: {{ class }}.self)] = newInstance
+        mutex.unlock()
+
+        return newInstance
     }
     {% call addPropertyWrappers dep %}
-    private func _get_{{ class|lowerFirstLetter }}() -> {{ class }} {
+    private var new{{ class }}: {{ class }} {
         return {{ dep.name }}({% for initializer in dep.initializers %}{% if not initializer.isConvenienceInitializer %}{% for param in initializer.parameters %}{{ param.name }}: self.{{ param.typeName|lowerFirstLetter }}{% if not forloop.last%}, {% endif %}{% endfor %}{% endif %}{% endfor %})
     }
     {% else %}

--- a/Source/Type/PendingTasksRunnerResult.swift
+++ b/Source/Type/PendingTasksRunnerResult.swift
@@ -60,7 +60,7 @@ public extension PendingTasksRunnerResult {
     /**
      Get first [TaskRunResult] that was a failed attempt. Note: This failed attempt could have been a task that failed or one that skipped.
      */
-    public var firstFailedResult: TaskRunResult? {
+    var firstFailedResult: TaskRunResult? {
         return runResults.first(where: { runResult in
             switch runResult {
             case .failure, .skipped:
@@ -74,7 +74,7 @@ public extension PendingTasksRunnerResult {
     /**
      cancelled are OK. They count as successful. Skipped means that they need to be run again so, that's not successful.
      */
-    public var successful: Bool {
+    var successful: Bool {
         return firstFailedResult == nil
     }
 }

--- a/Source/Wendy.swift
+++ b/Source/Wendy.swift
@@ -42,11 +42,11 @@ public class Wendy {
     }
     
     public final func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
-        let addedTask = PendingTasksManager.shared.add(tag: tag, dataId: dataId, groupId: groupId)
+        let addedTask = DIGraph.shared.pendingTasksManager.add(tag: tag, dataId: dataId, groupId: groupId)
 
         WendyConfig.logNewTaskAdded(addedTask)
 
-        try runTaskAutomaticallyIfAbleTo(addedTask)
+        runTaskAutomaticallyIfAbleTo(addedTask)
 
         return addedTask.taskId!
     }
@@ -60,12 +60,13 @@ public class Wendy {
 
      Those make this function unique compared to `runTask()` because that function ignores WendyConfig.automaticallyRunTasks *and* if the task.manuallyRun property is set or not.
      */
+    @discardableResult
     internal func runTaskAutomaticallyIfAbleTo(_ task: PendingTask) -> Bool {
         if !WendyConfig.automaticallyRunTasks {
             LogUtil.d("Wendy configured to not automatically run tasks. Skipping execution of newly added task: \(task.describe())")
             return false
         }
-        if try !isTaskAbleToManuallyRun(task.taskId!) {
+        if !isTaskAbleToManuallyRun(task.taskId!) {
             LogUtil.d("Task is not able to manually run. Skipping execution of newly added task: \(task.describe())")
             return false
         }
@@ -77,7 +78,7 @@ public class Wendy {
     }
 
     public final func runTask(_ taskId: Double, onComplete: ((TaskRunResult) -> Void)?) {
-        guard let pendingTask: PendingTask = PendingTasksManager.shared.getTaskByTaskId(taskId) else {
+        guard let pendingTask: PendingTask = DIGraph.shared.pendingTasksManager.getTaskByTaskId(taskId) else {
             onComplete?(TaskRunResult.cancelled)
             return
         }
@@ -92,7 +93,7 @@ public class Wendy {
     }
 
     public final func isTaskAbleToManuallyRun(_ taskId: Double) -> Bool {
-        guard let pendingTask: PendingTask = PendingTasksManager.shared.getTaskByTaskId(taskId) else {
+        guard let pendingTask: PendingTask = DIGraph.shared.pendingTasksManager.getTaskByTaskId(taskId) else {
             return false
         }
 
@@ -136,7 +137,7 @@ public class Wendy {
     }
 
     public final func getAllTasks() -> [PendingTask] {
-        return PendingTasksManager.shared.getAllTasks()
+        return DIGraph.shared.pendingTasksManager.getAllTasks()
     }
 
     /**
@@ -156,7 +157,7 @@ public class Wendy {
     }
     
     public func addQueueReader(_ reader: QueueReader) {
-        PendingTasksManager.shared.addQueueReader(reader)
+        DIGraph.shared.pendingTasksManager.addQueueReader(reader)
     }
     
     struct InitializedData {

--- a/Tests/PendingTasksManagerTests.swift
+++ b/Tests/PendingTasksManagerTests.swift
@@ -16,7 +16,7 @@ class PendingTasksManagerTest: TestClass {
     private var queueReader2: QueueReaderStub!
         
     private var pendingTasksManager: PendingTasksManager {
-        PendingTasksManager.shared
+        DIGraph.shared.pendingTasksManager
     }
         
         override func setUp() {
@@ -25,7 +25,7 @@ class PendingTasksManagerTest: TestClass {
             queueReader = QueueReaderStub()
             queueReader2 = QueueReaderStub()
             
-            PendingTasksManager.initForTesting(queueReaders: [queueReader, queueReader2])
+            pendingTasksManager.queueReaders = [queueReader, queueReader2]
         }
     
     // MARK: getAllTasks

--- a/Tests/Store/FileSystemQueueIntegrationTest.swift
+++ b/Tests/Store/FileSystemQueueIntegrationTest.swift
@@ -11,17 +11,11 @@ import Foundation
 import XCTest
 
 class FileSystemQueueIntegrationTest: TestClass {
-    private var reader: FileSystemQueueReader!
-    private var writer: FileSystemQueueWriter {
-        return FileSystemQueueWriter.shared
+    private var reader: FileSystemQueueReader {
+        DIGraph.shared.queueReader as! FileSystemQueueReader
     }
-    
-    override func setUp() {
-        super.setUp()
-        
-        FileSystemQueueImpl.reset()
-
-        reader = FileSystemQueueReader()
+    private var writer: FileSystemQueueWriter {
+        DIGraph.shared.queueWriter as! FileSystemQueueWriter
     }
     
     // MARK: simple reading and writing
@@ -53,7 +47,7 @@ class FileSystemQueueIntegrationTest: TestClass {
     func test_givenAddTasks_givenClearMemory_expectLoadPreviouslyAddedTasks() {
         let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
         
-        FileSystemQueueImpl.reset()
+        resetDependencies()
         
         let actual = reader.getAllTasks()
         XCTAssertEqual(actual[0].taskId, 1)

--- a/Tests/TestClass.swift
+++ b/Tests/TestClass.swift
@@ -17,15 +17,15 @@ open class TestClass: XCTestCase {
         deleteKeyValueStore()
         deleteAllFileSystemFiles()
         
-        // Reset singletons
-        DIGraph.shared.reset()
-        FileSystemQueueImpl.reset()
-        FileSystemQueueWriter.reset()
-        Wendy.reset()
-        PendingTasksManager.reset()
+        resetDependencies()
         
         // Prevent scheduling any runs automatically. Makes tests flaky.
         WendyConfig.automaticallyRunTasks = false
+    }
+    
+    public func resetDependencies() {
+        DIGraph.shared.reset()
+        Wendy.reset()
     }
     
 }


### PR DESCRIPTION
Refactor all singletons and non-singletons to be added to the digraph. Also, refactor all code that needs to get a dependency to use the digraph.

I needed to fix the digraph generation code because the automated tests found a couple bugs in the generated digraph code. Changed the graph to use a mutex instead of DispatchQueue. Exceptions were occurring when we needed to create too many DispatchQueues which can happen if you need to get a dependency singleton which depends on many singletons.

---

**Stack**:
- #110 ⬅
- #109
- #108


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*