### PR TITLE
build!: set min iOS version to 13 to enable Swift concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 let package = Package(
     name: "Wendy",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "Wendy", targets: ["Wendy"])

--- a/Wendy.podspec
+++ b/Wendy.podspec
@@ -31,7 +31,7 @@ Wendy is a FIFO task runner. You give it tasks, one by one, it persists those ta
   s.source           = { :git => 'https://github.com/levibostian/Wendy-iOS.git', :tag => s.version.to_s }
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '13.0'
 
   s.source_files = 'Source/**/*'
 


### PR DESCRIPTION
BREAKING CHANGE: Min iOS version requirement has gone from iOS 11 to 13.

swift concurrency is only available in iOS 13.

---

**Stack**:
- #113
- #112
- #111 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*