### PR TITLE
feat: add task runner with async runTask function instead of a completion handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ class MyWendyTaskRunner: WendyTaskRunner {
     func runTask(tag: String, dataId: String?, complete: @escaping (Error?) -> Void) {
     }
 }
+
+// Or, use the Swift Concurrency version: 
+class MyWendyTaskRunner: WendyTaskRunnerConcurrency {
+    func runTask(tag: String, dataId: String?) async throws {
+    }
+}
 ```
 
 Wendy is now configured. It's time to use it!

--- a/Source/Wendy.swift
+++ b/Source/Wendy.swift
@@ -5,7 +5,7 @@ public class Wendy {
     
     private var initializedData: InitializedData? = nil // populated after setup() called.
         
-    internal var taskRunner: WendyTaskRunner? {
+    internal var taskRunner: WendyTaskRunnerConcurrency? {
         initializedData?.taskRunner
     }
     
@@ -26,6 +26,10 @@ public class Wendy {
     }
 
     public class func setup(taskRunner: WendyTaskRunner, debug: Bool = false) {
+        Self.setup(taskRunner: LegayTaskRunnerAdapter(taskRunner: taskRunner), debug: debug)
+    }
+    
+    public class func setup(taskRunner: WendyTaskRunnerConcurrency, debug: Bool = false) {
         Wendy.shared.initializedData = InitializedData(taskRunner: taskRunner)
         WendyConfig.debug = debug
         
@@ -158,12 +162,12 @@ public class Wendy {
     }
     
     struct InitializedData {
-        let taskRunner: WendyTaskRunner
+        let taskRunner: WendyTaskRunnerConcurrency
     }
 }
 
 extension DIGraph {
-    var taskRunner: WendyTaskRunner? {
+    var taskRunner: WendyTaskRunnerConcurrency? {
         return Wendy.shared.taskRunner
     }
 }

--- a/Source/WendyTaskRunner.swift
+++ b/Source/WendyTaskRunner.swift
@@ -7,6 +7,33 @@
 
 import Foundation
 
+/// Version of the Task runner that uses Swift Concurrency.
+/// In the future, this protocol may replace the default one.
+public protocol WendyTaskRunnerConcurrency {
+    func runTask(tag: String, dataId: String?) async throws
+}
+
 public protocol WendyTaskRunner {
     func runTask(tag: String, dataId: String?, complete: @escaping (Error?) -> Void)
+}
+
+// Adapter for us to just use WendyTaskRunnerConcurrency in the internal code rather then having to deal with 2 protocols.
+internal class LegayTaskRunnerAdapter: WendyTaskRunnerConcurrency {
+    private let taskRunner: WendyTaskRunner
+    
+    init(taskRunner: WendyTaskRunner) {
+        self.taskRunner = taskRunner
+    }
+    
+    public func runTask(tag: String, dataId: String?) async throws {
+        let _: Void = try await withCheckedThrowingContinuation { continuation in
+            taskRunner.runTask(tag: tag, dataId: dataId) { error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
 }

--- a/Tests/Stubs/TaskRunnerStub.swift
+++ b/Tests/Stubs/TaskRunnerStub.swift
@@ -11,23 +11,35 @@ import Foundation
 class TaskRunnerStub: WendyTaskRunner {
     
     @Atomic var resultsQueue: [Result<Void?, Error>] = []
-    var runTaskClosure: ((String, String?, @escaping (Error?) -> Void) -> Void)? = nil
+    var runTaskClosure: ((String, String?) async throws -> Void)? = nil
     
     func runTask(tag: String, dataId: String?, complete: @escaping (Error?) -> Void) {
+        // there are 2 ways for stub to run a task.
+        
+        // First, check if there is a closure that implements the function body.
         if let runTaskClosure {
-            runTaskClosure(tag, dataId, complete)
-            return
-        }
-        
-        let result = resultsQueue.removeFirst()
-        
-        switch result {
-            case .success:
-                complete(nil)
-                break
-            case .failure(let error):
-                complete(error)
-                break
+            Task {
+                do {
+                    try await runTaskClosure(tag, dataId)
+                    complete(nil)
+                } catch {
+                    complete(error)
+                }
+                
+                return
+            }
+        } else {
+            // Otherwise, process the queue of return results.
+            let result = resultsQueue.removeFirst()
+            
+            switch result {
+                case .success:
+                    complete(nil)
+                    break
+                case .failure(let error):
+                    complete(error)
+                    break
+            }
         }
     }
 }

--- a/Tests/WendyIntegrationTests.swift
+++ b/Tests/WendyIntegrationTests.swift
@@ -208,7 +208,7 @@ class WendyIntegrationTests: TestClass {
         let expectToFinishRuningAllTasks = expectation(description: "expect to finish running all tasks")
         let expectToFinishRunningSingleTask = expectation(description: "expect to finish running single task")
         
-        taskRunnerStub.runTaskClosure = { tagOfTaskWeAreRunning, _, onComplete in
+        taskRunnerStub.runTaskClosure = { tagOfTaskWeAreRunning, _ in
             
             // When we begin running all tasks, ask Wendy to run task 3, which means it would run it before task 2.
             if tagOfTaskWeAreRunning == "task1" {
@@ -224,8 +224,6 @@ class WendyIntegrationTests: TestClass {
             } else if tagOfTaskWeAreRunning == "task3" {
                 expectToRunTask3.fulfill()
             }
-            
-            onComplete(nil)
         }
         
         Wendy.shared.runTasks { _ in
@@ -248,16 +246,13 @@ class WendyIntegrationTests: TestClass {
         _ = Wendy.shared.addTask(tag: "task1", dataId: "dataId")
         _ = Wendy.shared.addTask(tag: "task2", dataId: "dataId")
         
-        taskRunnerStub.runTaskClosure = { tagOfTaskWeAreRunning, _, onComplete in
-            
+        taskRunnerStub.runTaskClosure = { tagOfTaskWeAreRunning, _ in
             // When we begin running all tasks, ask Wendy to run all tasks again. The request should be ignored so it should complete fast.
             if tagOfTaskWeAreRunning == "task1" {
                 Wendy.shared.runTasks { _ in
                     expectToIgnoreRequestToRunAllTasks.fulfill()
                 }
             }
-            
-            onComplete(nil)
         }
         
         Wendy.shared.runTasks { _ in
@@ -268,26 +263,6 @@ class WendyIntegrationTests: TestClass {
             expectToIgnoreRequestToRunAllTasks,
             expectToFinishRunningAllTasks,
         ], timeout: 1.0, enforceOrder: true)
-    }
-    
-    func test_runAllTasks_givenDeinitWendy_expectCancelRunningTasks() {
-        _ = Wendy.shared.addTask(tag: "task1", dataId: "dataId")
-        
-        let expectToFinishRunningAllTasks = expectation(description: "expect to finish running all tasks")
-        
-        taskRunnerStub.runTaskClosure = { _, _, _ in
-            // never finish, since it will be canceled.
-        }
-        
-        Wendy.shared.runTasks { _ in
-            expectToFinishRunningAllTasks.fulfill()
-        }
-        
-        Wendy.reset() // deinit
-    
-        wait(for: [
-            expectToFinishRunningAllTasks
-        ], timeout: 1.0)
     }
     
     // MARK: clear


### PR DESCRIPTION
First swift concurrency change to the public api. Trying to make using Wendy easier with an easier to use API.

This change was made in a backwards compatible way to introducing a new protocol data type. This was done because of how new Swift concurrency features are. I can imagine as swift 6 gets closer, we may make this new protocol replace the default one.

---

**Stack**:
- #115
- #114 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*