### PR TITLE
feat: use a string or enum to add and run tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ To tell Wendy that you have a piece of data that needs to sync with a network AP
 
 ```swift
 Wendy.shared.addTask(tag: "AddGroceryListItem", dataId: "<identifier-here>") 
+
+// Or, use an enum to avoid hard-coded strings: 
+enum AsyncTasks: String {
+  case addGroceryListItem
+}
+
+Wendy.shared.addTask(tag: AsyncTasks.addGroceryListItem, dataId: "<identifier-here>")
 ```
 
 * `tag` is the data type identifier. It’s common to use 1 `tag`  per network API endpoint. Here, we use `AddGroceryListItem` because the user added a new grocery store list item. 
@@ -132,6 +139,13 @@ class MyWendyTaskRunner: WendyTaskRunner {
          }
          break 
     }
+}
+
+// If you prefer to use enums instead of hard-coded strings, you can do that, too:
+func runTask(tag: String, dataId: String?, complete: @escaping (Error?) -> Void) {
+  switch AsyncTask(rawValue: tag) {
+    case .addGroceryListItem:
+  }
 }
 ```
 

--- a/Source/Wendy.swift
+++ b/Source/Wendy.swift
@@ -44,6 +44,10 @@ final public class Wendy: Sendable {
         return addedTask.taskId!
     }
     
+    public func addTask<Tag: RawRepresentable>(tag: Tag, dataId: String?, groupId: String? = nil) -> Double where Tag.RawValue == String {
+        self.addTask(tag: tag.rawValue, dataId: dataId, groupId: groupId)
+    }
+    
     /**
          * Note: This function is for internal use only. There are no checks to make sure that it exists and stuff. It's assumed you know what you're doing.
 

--- a/Tests/WendyIntegrationTests.swift
+++ b/Tests/WendyIntegrationTests.swift
@@ -35,6 +35,24 @@ class WendyIntegrationTests: TestClass {
         XCTAssertNotEqual(taskGroup1, taskGroup2)
     }
     
+    func test_addTasks_expectAddTasksAndRunTasksGivenEnumInsteadOfStrings() async {
+        enum AsyncTasks: String {
+            case foo
+        }
+        
+        let givenTag = AsyncTasks.foo
+        
+        let _ = Wendy.shared.addTask(tag: givenTag, dataId: "dataId")
+        
+        taskRunnerStub.runTaskClosure = { tag, dataId in
+            let actualTag = AsyncTasks(rawValue: tag)
+            
+            XCTAssertEqual(actualTag, givenTag)
+        }
+        
+        let _ = await runAllTasks()
+    }
+    
     // MARK: run tasks
     
     func test_runTasks_givenNoTasksAdded_expectRunNoTasks() async {


### PR DESCRIPTION
For convenience, adding functions that allows you to use enums instead of hard-coded strings easier.

commit-id:e9dcefc5