### PR TITLE
feat!: add tasks with Codable data instead of just a String

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -122,6 +122,30 @@ This feature was removed because it does not add a lot of value to the project.
 
 If you want to periodically run Wendy in your app, it’s recommended to review up-to-date documentation for how to run background jobs on iOS and run Wendy in that job: `Wendy.shared. runTasks {...}`. 
 
+# v7 to v8 - Replace `dataId` with `data: Codable` in task runner
+
+The breaking change that caused Wendy to go from v7 to v8 is replacing the parameter `dataId: String?` with `data: Codable` in task runner subclasses. This change brings a lot of power to Wendy because you can now use objects instead of just Strings when you add tasks to Wendy. Less code for you to write later to perform your API calls! 
+
+To migrate to v8, you will want to make sure that your tasks added with v7 of Wendy will continue to run. Here is some code to help you continue to use `dataId: String` for your existing tasks: 
+
+```
+import Wendy
+
+class MyWendyTaskRunner: WendyTaskRunner {
+    // 1. Change parameter 'dataId: String?' to 'data: Data?'
+    func runTask(tag: String, data: Data?, complete: @escaping (Error?) -> Void) {
+      switch tag {
+        case "AddGroceryListItem":
+          // 2. Convert the 'Data' data type back into 'String', as you were using before: 
+          let dataId: String? = data?.wendyDecode()
+          // 3. Done! Use 'dataId' as you were before! 
+          ...
+    }
+}
+```
+
+Your task runner can use the new `Codable` feature, too. Use the `tag` to differentiate between tasks that were added in Wendy version \< 8 and tasks added in version \>= 8. See the README to learn how to use this new feature. 
+
 [1]:	https://github.com/levibostian/Wendy-iOS/discussions/51
 [2]:	BEST_PRACTICES.md#after-i-add-a-task-to-wendy-what-updates-should-i-make-to-my-apps-local-data-storage
 [3]:	BEST_PRACTICES.md#handle-errors-when-a-task-runs

--- a/Source/Extensions/DataExtensions.swift
+++ b/Source/Extensions/DataExtensions.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Levi Bostian on 3/26/24.
+//
+
+import Foundation
+
+public extension Data {
+    func wendyDecode<Data: Codable>() -> Data? {        
+        return DIGraph.shared.jsonAdapter.fromData(self)
+    }
+}

--- a/Source/Extensions/PendingTask+Extensions.swift
+++ b/Source/Extensions/PendingTask+Extensions.swift
@@ -3,13 +3,13 @@ import Foundation
 public extension PendingTask {
     func describe() -> String {
         let taskIdString: String = (taskId != nil) ? String(describing: taskId!) : "none"
-        let dataIdString: String = (dataId != nil) ? String(describing: dataId!) : "none"
+        let dataString: String = (data != nil) ? String(describing: data!) : "none"
         let groupIdString: String = (groupId != nil) ? String(describing: groupId!) : "none"
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MM-dd-yyyy HH:mm:ss Z"
         let createdAtString: String = (createdAt != nil) ? dateFormatter.string(from: createdAt!) : "none"
 
-        return "taskId: \(taskIdString) dataId: \(dataIdString) groupId: \(groupIdString) createdAt: \(createdAtString)"
+        return "taskId: \(taskIdString) data: \(dataString) groupId: \(groupIdString) createdAt: \(createdAtString)"
     }
 
     func addTaskStatusListenerForTask(listener: PendingTaskStatusListener) {

--- a/Source/Extensions/_PendingTask+Extensions.swift
+++ b/Source/Extensions/_PendingTask+Extensions.swift
@@ -4,6 +4,6 @@ internal extension PendingTask {
     // Using instead of Equatable protocol because Swift does not allow a protocol inherit another protocol *and* I don't want the subclass to inherit Equatable, I just want to internally.
     func equals(_ other: PendingTask) -> Bool {
         return tag == other.tag &&
-            dataId == other.dataId
+            data == other.data
     }
 }

--- a/Source/PendingTask.swift
+++ b/Source/PendingTask.swift
@@ -3,14 +3,14 @@ import Foundation
 public struct PendingTask: Codable, Sendable {
     public let tag: String
     public let taskId: Double? // populated later
-    public let dataId: String?
+    public let data: Data?
     public let groupId: String?
     public let createdAt: Date? // populated later
-        
-    public init(tag: String, taskId: Double?, dataId: String?, groupId: String?, createdAt: Date?) {
+    
+    public init(tag: String, taskId: Double?, data: Data?, groupId: String?, createdAt: Date?) {
         self.tag = tag
         self.taskId = taskId
-        self.dataId = dataId
+        self.data = data
         self.groupId = groupId
         self.createdAt = createdAt
     }

--- a/Source/PendingTasksManager.swift
+++ b/Source/PendingTasksManager.swift
@@ -17,8 +17,8 @@ internal final class PendingTasksManager: QueueReader, QueueWriter, Sendable {
         ])
     }
 
-    func add(tag: String, dataId: String?, groupId: String?) -> PendingTask {
-        return queueWriter.get().add(tag: tag, dataId: dataId, groupId: groupId)
+    func add<Data>(tag: String, data: Data, groupId: String?) -> PendingTask where Data : Decodable, Data : Encodable {
+        return queueWriter.get().add(tag: tag, data: data, groupId: groupId)
     }
 
     internal func getAllTasks() -> [PendingTask] {

--- a/Source/PendingTasksRunner.swift
+++ b/Source/PendingTasksRunner.swift
@@ -73,7 +73,7 @@ public final class PendingTasksRunner: Sendable {
             LogUtil.d("Running task: \(taskToRun.describe())")
             
                 do {
-                    try await taskRunner.runTask(tag: taskToRun.tag, dataId: taskToRun.dataId)
+                    try await taskRunner.runTask(tag: taskToRun.tag, data: taskToRun.data)
                     
                     self.currentlyRunningTask.set(nil)
                     

--- a/Source/Store/QueueWriter.swift
+++ b/Source/Store/QueueWriter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol QueueWriter {
-    func add(tag: String, dataId: String?, groupId: String?) -> PendingTask
+    func add<Data: Codable>(tag: String, data: Data, groupId: String?) -> PendingTask
     func delete(taskId: Double) -> Bool
 }
 

--- a/Source/Util/JsonAdapter.swift
+++ b/Source/Util/JsonAdapter.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 internal protocol JsonAdapter {
-    func toData(_ object: Codable) -> Data?
+    func toData(_ object: Codable?) -> Data?
     func fromData<T: Codable>(_ data: Data) -> T?
 }
 
@@ -18,7 +18,11 @@ internal class JsonAdapterImpl: JsonAdapter {
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
     
-    func toData(_ object: Codable) -> Data? {
+    func toData(_ object: Codable?) -> Data? {
+        guard let object = object else {
+            return nil
+        }
+        
         do {
             return try encoder.encode(object)
         } catch {

--- a/Source/Wendy.swift
+++ b/Source/Wendy.swift
@@ -22,7 +22,7 @@ final public class Wendy: Sendable {
     }
 
     public class func setup(taskRunner: WendyTaskRunner, debug: Bool = false) {
-        Self.setup(taskRunner: LegayTaskRunnerAdapter(taskRunner: taskRunner), debug: debug)
+        Self.setup(taskRunner: LegacyTaskRunnerAdapter(taskRunner: taskRunner), debug: debug)
     }
     
     public class func setup(taskRunner: WendyTaskRunnerConcurrency, debug: Bool = false) {
@@ -34,8 +34,8 @@ final public class Wendy: Sendable {
         // FileSystemQueueImpl.shared.load()
     }
     
-    public func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
-        let addedTask = DIGraph.shared.pendingTasksManager.add(tag: tag, dataId: dataId, groupId: groupId)
+    public func addTask<Data: Codable>(tag: String, data: Data?, groupId: String? = nil) -> Double {
+        let addedTask = DIGraph.shared.pendingTasksManager.add(tag: tag, data: data, groupId: groupId)
 
         LogUtil.logNewTaskAdded(addedTask)
 
@@ -44,8 +44,8 @@ final public class Wendy: Sendable {
         return addedTask.taskId!
     }
     
-    public func addTask<Tag: RawRepresentable>(tag: Tag, dataId: String?, groupId: String? = nil) -> Double where Tag.RawValue == String {
-        self.addTask(tag: tag.rawValue, dataId: dataId, groupId: groupId)
+    public func addTask<Tag: RawRepresentable, Data: Codable>(tag: Tag, data: Data?, groupId: String? = nil) -> Double where Tag.RawValue == String {
+        self.addTask(tag: tag.rawValue, data: data, groupId: groupId)
     }
     
     /**
@@ -128,6 +128,19 @@ final public class Wendy: Sendable {
     
     struct InitializedData {
         let taskRunner: WendyTaskRunnerConcurrency
+    }
+}
+
+// Public API functions for backwards compatibility.
+public extension Wendy {
+    @available(*, deprecated, message: "Use addTask(tag:data:groupId:) instead.")
+    func addTask(tag: String, dataId: String?, groupId: String? = nil) -> Double {
+        return self.addTask(tag: tag, data: dataId, groupId: groupId)
+    }
+    
+    @available(*, deprecated, message: "Use addTask(tag:data:groupId:) instead.")
+    func addTask<Tag: RawRepresentable>(tag: Tag, dataId: String?, groupId: String? = nil) -> Double where Tag.RawValue == String {
+        self.addTask(tag: tag.rawValue, data: dataId, groupId: groupId)
     }
 }
 

--- a/Source/WendyTaskRunner.swift
+++ b/Source/WendyTaskRunner.swift
@@ -10,24 +10,26 @@ import Foundation
 /// Version of the Task runner that uses Swift Concurrency.
 /// In the future, this protocol may replace the default one.
 public protocol WendyTaskRunnerConcurrency {
-    func runTask(tag: String, dataId: String?) async throws
+    func runTask(tag: String, data: Data?) async throws
 }
 
 public protocol WendyTaskRunner {
-    func runTask(tag: String, dataId: String?, complete: @Sendable @escaping (Error?) -> Void)
+    func runTask(tag: String, data: Data?, complete: @Sendable @escaping (Error?) -> Void)
 }
 
+// MARK: backwards compatibility, non-async runner
+
 // Adapter for us to just use WendyTaskRunnerConcurrency in the internal code rather then having to deal with 2 protocols.
-internal class LegayTaskRunnerAdapter: WendyTaskRunnerConcurrency {
+internal class LegacyTaskRunnerAdapter: WendyTaskRunnerConcurrency {
     private let taskRunner: WendyTaskRunner
     
     init(taskRunner: WendyTaskRunner) {
         self.taskRunner = taskRunner
     }
     
-    public func runTask(tag: String, dataId: String?) async throws {
+    func runTask(tag: String, data: Data?) async throws {
         let _: Void = try await withCheckedThrowingContinuation { continuation in
-            taskRunner.runTask(tag: tag, dataId: dataId) { error in
+            taskRunner.runTask(tag: tag, data: data) { error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else {

--- a/Tests/PendingTasksManagerTests.swift
+++ b/Tests/PendingTasksManagerTests.swift
@@ -40,9 +40,9 @@ class PendingTasksManagerTest: TestClass {
     }
     
     func test_getAllTasks_expectTasksSorted() {
-        let givenOldestTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
-        let givenMiddleTask = PendingTask(tag: "bar", taskId: 2, dataId: nil, groupId: nil, createdAt: Date().addingTimeInterval(1))
-        let givenNewestTask = PendingTask(tag: "baz", taskId: 3, dataId: nil, groupId: nil, createdAt: Date().addingTimeInterval(2))
+        let givenOldestTask = PendingTask(tag: "foo", taskId: 1, data: nil, groupId: nil, createdAt: Date())
+        let givenMiddleTask = PendingTask(tag: "bar", taskId: 2, data: nil, groupId: nil, createdAt: Date().addingTimeInterval(1))
+        let givenNewestTask = PendingTask(tag: "baz", taskId: 3, data: nil, groupId: nil, createdAt: Date().addingTimeInterval(2))
         
         queueReader.allTasks = [givenMiddleTask]
         queueReader2.allTasks = [givenNewestTask, givenOldestTask]
@@ -57,8 +57,8 @@ class PendingTasksManagerTest: TestClass {
     // MARK: getTaskByTaskId
     
     func test_getTaskByTaskId_givenTaskExists_expectTask() {
-        let givenTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
-        let givenTaskWithDifferentId = PendingTask(tag: "foo", taskId: 2, dataId: nil, groupId: nil, createdAt: Date())
+        let givenTask = PendingTask(tag: "foo", taskId: 1, data: nil, groupId: nil, createdAt: Date())
+        let givenTaskWithDifferentId = PendingTask(tag: "foo", taskId: 2, data: nil, groupId: nil, createdAt: Date())
         
         queueReader.allTasks = [givenTask]
         queueReader2.allTasks = [givenTaskWithDifferentId]
@@ -69,8 +69,8 @@ class PendingTasksManagerTest: TestClass {
     }
     
     func test_getTaskByTaskId_givenTaskDoesNotExist_expectNil() {
-        queueReader.allTasks = [PendingTask(tag: "foo", taskId: 2, dataId: nil, groupId: nil, createdAt: Date())]
-        queueReader2.allTasks = [PendingTask(tag: "foo", taskId: 3, dataId: nil, groupId: nil, createdAt: Date())]
+        queueReader.allTasks = [PendingTask(tag: "foo", taskId: 2, data: nil, groupId: nil, createdAt: Date())]
+        queueReader2.allTasks = [PendingTask(tag: "foo", taskId: 3, data: nil, groupId: nil, createdAt: Date())]
         
         let actual = pendingTasksManager.getTaskByTaskId(1)
         
@@ -89,7 +89,7 @@ class PendingTasksManagerTest: TestClass {
     }
     
     func test_getNextTaskToRun_givenTaskInMultipleReaders_expectGetTask() {
-        let givenTask = PendingTask(tag: "foo", taskId: 1, dataId: nil, groupId: nil, createdAt: Date())
+        let givenTask = PendingTask(tag: "foo", taskId: 1, data: nil, groupId: nil, createdAt: Date())
         
         queueReader.allTasks = []
         queueReader2.allTasks = [givenTask]

--- a/Tests/Store/FileSystemQueueIntegrationTest.swift
+++ b/Tests/Store/FileSystemQueueIntegrationTest.swift
@@ -27,13 +27,13 @@ class FileSystemQueueIntegrationTest: TestClass {
     }
     
     func test_getTaskById_givenNoTaskWithId_expectNil() {
-        let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
+        let _ = writer.add(tag: "foo", data: "", groupId: nil)
         XCTAssertNil(reader.getTaskByTaskId(2))
         XCTAssertNotNil(reader.getTaskByTaskId(1))
     }
     
     func test_givenDeleteTask_expectTaskGotDeleted() {
-        let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
+        let _ = writer.add(tag: "foo", data: "", groupId: nil)
         
         XCTAssertNotNil(reader.getTaskByTaskId(1))
         
@@ -45,7 +45,7 @@ class FileSystemQueueIntegrationTest: TestClass {
     // MARK: persist tasks to data store
     
     func test_givenAddTasks_givenClearMemory_expectLoadPreviouslyAddedTasks() {
-        let _ = writer.add(tag: "foo", dataId: nil, groupId: nil)
+        let _ = writer.add(tag: "foo", data: "", groupId: nil)
         
         resetDependencies()
         

--- a/Tests/Stubs/TaskRunnerStub.swift
+++ b/Tests/Stubs/TaskRunnerStub.swift
@@ -11,21 +11,21 @@ import Foundation
 final class TaskRunnerStub: WendyTaskRunner, Sendable {
     
     let _resultsQueue: MutableSendable<[Result<Void?, Error>]> = MutableSendable([])
-    let _runTaskClosure: MutableSendable<((String, String?) async throws -> Void)?> = MutableSendable(nil)
+    let _runTaskClosure: MutableSendable<((String, Data?) async throws -> Void)?> = MutableSendable(nil)
     
     var resultsQueue: [Result<Void?, Error>] {
         get { _resultsQueue.get() }
         set { _resultsQueue.set(newValue) }
     }
-    var runTaskClosure: ((String, String?) async throws -> Void)? {
+    var runTaskClosure: ((String, Data?) async throws -> Void)? {
         get { _runTaskClosure.get() }
         set { _runTaskClosure.set(newValue) }
     }
     
-    func runTask(tag: String, dataId: String?, complete: @Sendable @escaping (Error?) -> Void) {
+    func runTask(tag: String, data: Data?, complete: @Sendable @escaping (Error?) -> Void) {
         Task {
             do {
-                try await runTask(tag: tag, dataId: dataId)
+                try await runTask(tag: tag, data: data)
                 complete(nil)
             } catch {
                 complete(error)
@@ -33,12 +33,12 @@ final class TaskRunnerStub: WendyTaskRunner, Sendable {
         }
     }
     
-    private func runTask(tag: String, dataId: String?) async throws {
+    private func runTask(tag: String, data: Data?) async throws {
         // there are 2 ways for stub to run a task.
         
         // First, check if there is a closure that implements the function body.
         if let runTaskClosure {
-            try await runTaskClosure(tag, dataId)
+            try await runTaskClosure(tag, data)
         } else {
             // Otherwise, process the queue of return results.
             let result = resultsQueue.removeFirst()

--- a/Tests/WendyIntegrationTests.swift
+++ b/Tests/WendyIntegrationTests.swift
@@ -24,15 +24,42 @@ class WendyIntegrationTests: TestClass {
     // MARK: adding tasks
     
     func test_addTasks_givenAddTasksWithSameArguments_expectEveryTaskUnique() {
-        let task1 = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
-        let task2 = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let task1 = Wendy.shared.addTask(tag: "tag", data: "dataId")
+        let task2 = Wendy.shared.addTask(tag: "tag", data: "dataId")
         
         XCTAssertNotEqual(task1, task2)
         
-        let taskGroup1 = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
-        let taskGroup2 = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
+        let taskGroup1 = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
+        let taskGroup2 = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
         
         XCTAssertNotEqual(taskGroup1, taskGroup2)
+    }
+    
+    func test_addTasks_givenDeprecatedDataId_expectToAddAndRunTaskUsingDataId() async {
+        enum Tag: String {
+            case foo
+        }
+        
+        let _ = Wendy.shared.addTask(tag: "string-tag", dataId: "string-dataId")
+        let _ = Wendy.shared.addTask(tag: Tag.foo, dataId: "enum-dataId")
+        
+        taskRunnerStub.runTaskClosure = { tag, data in
+            guard let dataId: String = data?.wendyDecode() else {
+                XCTFail("Could not decode data")
+                return
+            }
+            
+            switch tag {
+            case "string-tag":
+                XCTAssertEqual(dataId, "string-dataId")
+            case Tag.foo.rawValue:
+                XCTAssertEqual(dataId, "enum-dataId")
+            default:
+                XCTFail("Unexpected tag")
+            }
+        }
+        
+        let _ = await runAllTasks()
     }
     
     func test_addTasks_expectAddTasksAndRunTasksGivenEnumInsteadOfStrings() async {
@@ -42,12 +69,39 @@ class WendyIntegrationTests: TestClass {
         
         let givenTag = AsyncTasks.foo
         
-        let _ = Wendy.shared.addTask(tag: givenTag, dataId: "dataId")
+        let _ = Wendy.shared.addTask(tag: givenTag, data: "dataId")
         
-        taskRunnerStub.runTaskClosure = { tag, dataId in
+        taskRunnerStub.runTaskClosure = { tag, _ in
             let actualTag = AsyncTasks(rawValue: tag)
             
             XCTAssertEqual(actualTag, givenTag)
+        }
+        
+        let _ = await runAllTasks()
+    }
+    
+    func test_addTasks_givenProvideCobaleObject_expectGetObjectBackWhenRunTask() async {
+        struct CodableObject: Codable {
+            let foo: String
+            let nested: Nested
+            
+            struct Nested: Codable {
+                let bar: String
+            }
+        }
+        
+        let _ = Wendy.shared.addTask(tag: "foo", data: CodableObject(foo: .random, nested: .init(bar: .random)))
+        
+        taskRunnerStub.runTaskClosure = { tag, data in
+            switch tag {
+            case "foo":
+                guard let _: CodableObject = data?.wendyDecode() else {
+                    XCTFail("Could not decode data")
+                    return
+                }
+            default:
+                XCTFail("Unknown tag")
+            }
         }
         
         let _ = await runAllTasks()
@@ -65,7 +119,7 @@ class WendyIntegrationTests: TestClass {
             .success(nil)
         ]
         
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
         
         let runTasksResults = await runAllTasks()
         
@@ -84,7 +138,7 @@ class WendyIntegrationTests: TestClass {
             .failure(ErrorForTesting.foo)
         ]
         
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
         
         let runTasksResults = await runAllTasks()
         
@@ -108,8 +162,8 @@ class WendyIntegrationTests: TestClass {
         ]
 
         XCTAssertEqual(listener.newTaskAddedCallCount, 0)
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
         XCTAssertEqual(listener.newTaskAddedCallCount, 2)
         
         XCTAssertEqual(listener.runningTaskCallCount, 0)
@@ -130,7 +184,7 @@ class WendyIntegrationTests: TestClass {
             .success(nil)
         ]
         
-        let addedTaskId = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let addedTaskId = Wendy.shared.addTask(tag: "tag", data: "dataId")
         WendyConfig.addTaskStatusListenerForTask(addedTaskId, listener: listener)
         
         XCTAssertNil(listener.runningTaskId)
@@ -157,8 +211,8 @@ class WendyIntegrationTests: TestClass {
             .failure(ErrorForTesting.foo)
         ]
         
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
         
         let runTasksResults = await runAllTasks()
         
@@ -173,8 +227,8 @@ class WendyIntegrationTests: TestClass {
             .success(nil)
         ]
         
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId", groupId: "groupName")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId", groupId: "groupName")
         
         let runTasksResults = await runAllTasks()
         
@@ -191,12 +245,12 @@ class WendyIntegrationTests: TestClass {
         expectToAddTasks.expectedFulfillmentCount = 2
 
         Task {
-            let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+            let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
             expectToAddTasks.fulfill()
         }
         
         Task {
-            let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+            let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
             expectToAddTasks.fulfill()
         }
         
@@ -213,9 +267,9 @@ class WendyIntegrationTests: TestClass {
     
     // Wendy has the ability to run a single task whenever you want. So if wendy is running 100 tasks, for example, you can run a single task and not have to wait for wendy to finish running the rest of the 100 tasks.
     func test_runTask_givenAlreadyRunningAllTasks_expectBeAbleToRunSingleTaskInMiddleOfRunningAll() async {
-        _ = Wendy.shared.addTask(tag: "task1", dataId: "dataId")
-        _ = Wendy.shared.addTask(tag: "task2", dataId: "dataId")
-        _ = Wendy.shared.addTask(tag: "task3", dataId: "dataId")
+        _ = Wendy.shared.addTask(tag: "task1", data: "dataId")
+        _ = Wendy.shared.addTask(tag: "task2", data: "dataId")
+        _ = Wendy.shared.addTask(tag: "task3", data: "dataId")
         
         let expectToRunTask1 = expectation(description: "expect to run task 1")
         let expectToRunTask2 = expectation(description: "expect to run task 2")
@@ -258,8 +312,8 @@ class WendyIntegrationTests: TestClass {
         let expectToFinishRunningAllTasks = expectation(description: "expect to finish running all tasks")
         let expectToIgnoreRequestToRunAllTasks = expectation(description: "expect to ignore request to run all tasks")
         
-        _ = Wendy.shared.addTask(tag: "task1", dataId: "dataId")
-        _ = Wendy.shared.addTask(tag: "task2", dataId: "dataId")
+        _ = Wendy.shared.addTask(tag: "task1", data: "dataId")
+        _ = Wendy.shared.addTask(tag: "task2", data: "dataId")
         
         taskRunnerStub.runTaskClosure = { tagOfTaskWeAreRunning, _ in
             // When we begin running all tasks, ask Wendy to run all tasks again. The request should be ignored so it should complete fast.
@@ -283,8 +337,8 @@ class WendyIntegrationTests: TestClass {
     // MARK: clear
     
     func test_clearTasks_givenTasksAdded_expectAllCancelAndDelete() async {
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
-        let _ = Wendy.shared.addTask(tag: "tag", dataId: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
+        let _ = Wendy.shared.addTask(tag: "tag", data: "dataId")
         
         Wendy.shared.clear()
         


### PR DESCRIPTION
After using other queue implementations for a bit lately, using a String to represent the data requires much more boilerplate code. It reduces the developer experience.

With this change, you will have to write less code to add and run tasks. Focus instead on the networking code to sync.

commit-id:c519163d