### PR TITLE
ci: fix mint caching

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -13,30 +13,14 @@ runs:
     with:
       xcode-version: "15"
 
-  - name: Install package manager, Mint
-    run: brew install mint 
-    shell: bash
-
-  - name: Restore Mint cache, if exists 
-    uses: actions/cache@v4
-    with:
-      path: .mint
-      key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-      restore-keys: |
-        ${{ runner.os }}-mint-
-  
-  - name: Install tools in Mintfile 
-    env:
-      MINT_PATH: .mint/lib
-      MINT_LINK_PATH: .mint/bin
-    run: mint bootstrap 
-    shell: bash
-
   - name: Install development tool, Taskfile
     uses: arduino/setup-task@v2
     with:
       version: 3.x
       repo-token: ${{ inputs.repo-token }}
+
+  - name: Install package manager, Mint
+    uses: levibostian/setup-mint@skip-cache-mintbin-SNAPSHOT
 
   - name: Generate code to allow project to compile 
     run: task codegen 


### PR DESCRIPTION
Part of: https://github.com/levibostian/Wendy-iOS/issues/126

I have been experiencing 'mint bootstrap' re-installing package binaries. It's like mint is ignoring the cache. 

I was having great success with the setup-mint github action, but was experiencing a bug with it. I made a fork, attempted to fix the issue, and am trying to use the action again to fix mint caching.  

commit-id:d417b856