### PR TITLE
ci: fix mint installing

### DIFF
--- a/.github/actions/setup-ios/action.yml
+++ b/.github/actions/setup-ios/action.yml
@@ -20,7 +20,7 @@ runs:
       repo-token: ${{ inputs.repo-token }}
 
   - name: Install package manager, Mint
-    uses: levibostian/setup-mint@skip-cache-mintbin-SNAPSHOT
+    uses: irgaly/setup-mint@v1
 
   - name: Generate code to allow project to compile 
     run: task codegen 


### PR DESCRIPTION
My fork of setup-mint action no longer exists. Updating with the original that my fork merged into.

---

**Stack**:
- #146
- #147 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*