### PR TITLE
ci: make renovatebot less noisey

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
+  "timezone": "America/Chicago",
+  "schedule": ["every weekend"],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
+      "groupName": "Mint packages",
+      "matchManagers": [
+        "mint"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "automerge": true
     }
   ],


### PR DESCRIPTION
Group certain updates together. Run only once a weekend.

References: https://docs.renovatebot.com/noise-reduction/