### PR TITLE
ci: setup danger to prevent merging PRs that update SPM files but not cocoapods

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,17 @@
+on: [pull_request]
+
+permissions:
+  pull-requests: write # Write access needed to create a comment.
+
+jobs:
+  # Danger is a tool that can help during code reviews. Automate common 
+  # code review tasks. https://danger.systems/js/
+  # TL;DR - it runs script `dangerfile.js` on each pull request. 
+  danger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run danger 
+        run: npx danger@11 ci --dangerfile dangerfile.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,11 @@
+// The SDK is deployed to multiple dependency management softwares (Cocoapods and Swift Package Manager). 
+// This code tries to prevent forgetting to update metadata files for one but not the other. 
+let isSPMFilesModified = danger.git.modified_files.includes('Package.swift') 
+let isCococapodsFilesModified = danger.git.modified_files.filter((filePath) => filePath.endsWith('.podspec')).length > 0
+
+console.log(`SPM files modified: ${isSPMFilesModified}, CocoaPods: ${isCococapodsFilesModified}`)
+
+if (isSPMFilesModified || isCococapodsFilesModified) {
+  if (!isSPMFilesModified) { warn("Cocoapods files (*.podspec) were modified but Swift Package Manager files (Package.*) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }
+  if (!isCococapodsFilesModified) { warn("Swift Package Manager files (Package.*) were modified but Cocoapods files (*.podspec) files were not. This is error-prone when updating dependencies in one service but not the other. Double-check that you updated all of the correct files.") }
+}


### PR DESCRIPTION
Renovatebot auto-updates Package.swift file but not podspec files. Therefore, if renovatebot opens a PR that updates Package.swift files, let's also make sure to update coaopod files, too.

---

**Stack**:
- #156
- #155 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*