### PR TITLE
chore: try to get renovatebot to automerge the github action updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": ["config:best-practices", ":automergeDigest"],
   "timezone": "America/Chicago",
   "schedule": ["every weekend"],
   "packageRules": [


### PR DESCRIPTION
I have noticed that PRs that update github actions to use digests dont get automerged. I hope this fixes that.

commit-id:3b77e5d9