### PR TITLE
refactor!: make clear() async

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -146,12 +146,12 @@ class MyWendyTaskRunner: WendyTaskRunner {
 
 Your task runner can use the new `Codable` feature, too. Use the `tag` to differentiate between tasks that were added in Wendy version \< 8 and tasks added in version \>= 8. See the README to learn how to use this new feature. 
 
-# v8 to v9 - Removing callbacks in favor of Swift concurrency  alternatives 
+# v8 to v9 - Removing callbacks in favor of Swift concurrency  alternatives
 As I have continued to learn more about Swift Concurrency, I have continuously tried to improve the codebase for upcoming Swift 6 support with complete Swift concurrency checking enabled on the codebase. 
 
 As part of these efforts, the codebase has moved away from callback functions to using `async/await` for all operations. This impacts your code in 2 ways: 
 
-1. Your `WendyTaskRunner` is now using `async/await` instead of a callback function: 
+1. Your `WendyTaskRunner` is now using `async/await` instead of a callback function:
 ```swift
 // Before: 
 class MyWendyTaskRunner: WendyTaskRunner {
@@ -169,15 +169,17 @@ class MyWendyTaskRunner: WendyTaskRunner {
 }
 ```
 
-2. The public functions in `Wendy` that used a callback are now using `async/await`: 
+2. The public functions in `Wendy` that used a callback are now using `async/await`:
 ```swift
 // Before: 
 Wendy.shared.runTasks {}
 Wendy.shared.runTask("") {}
+Wendy.shared.clear()
 
 // Now: 
 await Wendy.shared.runTasks()
 await Wendy.shared.runTask("")
+await Wendy.shared.clear()
 ```
 
 ### Curious why this change was made?

--- a/Source/Wendy.swift
+++ b/Source/Wendy.swift
@@ -130,17 +130,15 @@ public final class Wendy: Sendable, Singleton {
 
      Note: If a task is currently running when clear() is called, that running task will be finish executing but will not run again in the future as it has been cancelled.
      */
-    public final func clear() {
+    public final func clear() async {
         /// It's not possible to stop a dispatch queue of tasks so there is no way to stop the currently running task runner.
         /// This solution of using UserDefaults to set a threshold solves that problem while also leaving Wendy untouched to continue running as usual. If we deleted all data, as Android's Wendy does, we would have potential issues with tasks that are still in the queue but core data and userdefaults being deleted causing potential crashes and IDs being misaligned.
         PendingTasksUtil.setValidPendingTasksIdThreshold()
         LogUtil.d("Wendy tasks set as cancelled. Currently scheduled Wendy tasks will all skip running.")
         // Run all tasks (including manually run tasks) as they are all cancelled so it allows them all to be cleared fro the queue now and listeners can get notified.
 
-        // clear() should be a synchronous function that returns instantly. So, just invalidate the tasks and the next time the queue runs, the tasks will get cancelled and deleted.
-//        for task in getAllTasks() {
-//            _ = await runTask(task.taskId!)
-//        }
+        // We want to make it so the next time the developer calls runTasks(), 0 tasks get run. To do that, you must run the queue to have all tasks deleted after they are marked as invalid.
+        await runTasks()
     }
 
     public func addQueueReader(_ reader: QueueReader) {

--- a/Tests/Integration/WendyIntegrationTests.swift
+++ b/Tests/Integration/WendyIntegrationTests.swift
@@ -273,7 +273,6 @@ class WendyIntegrationTests: TestClass {
 
         await Wendy.shared.clear()
 
-        sleep(1) // give wendy time to run all scheduled tasks that do the deleting.
         let runTasksResults = await runAllTasks()
         XCTAssertEqual(runTasksResults.numberTasksRun, 0)
     }


### PR DESCRIPTION
After recent commit that deleted non-async functions in the public API, we now need to use an async version of running tasks. So, we needed to decide how clear() is going to work. I think it's best that when clear is run, the expected outcome is that the next time you call runTasks(), 0 tasks get executed. The only way to guarantee that is make clear() async. So, that's what we are going to do.

---

**Stack**:
- #173
- #172 ⬅
- #171
- #170
- #169


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*