### PR TITLE
ci: fix deployments

### DIFF
--- a/.github/actions/setup-semantic-release/action.yml
+++ b/.github/actions/setup-semantic-release/action.yml
@@ -9,10 +9,11 @@ runs:
     with:
       node-version: 'lts/*'
 
+  # Using conventional v7 to fix bug https://github.com/semantic-release/release-notes-generator/issues/633
   - name: Install semantic-release plugins that we need for deployment of this project 
     run: >
-      npm install 
-      conventional-changelog-conventionalcommits 
+      npm install       
+      conventional-changelog-conventionalcommits@7
       @semantic-release/github 
       @semantic-release/git 
       semantic-release-recovery@beta


### PR DESCRIPTION
Seems like there is a bug with semantic-release plugins conflicting with latest major conventional commits. Reverting as issue suggests: https://github.com/semantic-release/release-notes-generator/issues/633

commit-id:b1f4a00c