### PR TITLE
ci: compile apps against local code to find issues faster

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,2 +1,3 @@
 *.xcodeproj/
 *.xcworkspace/
+Podfile.lock

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -2,5 +2,5 @@
 target :App do 
   use_frameworks!
 
-  pod 'Wendy', :git => 'https://github.com/levibostian/Wendy-iOS.git', :branch => 'latest'
+  pod 'Wendy', :path => '../../'
 end

--- a/app/ios/Source/View.swift
+++ b/app/ios/Source/View.swift
@@ -41,7 +41,9 @@ struct ContentView: View {
             Wendy.shared.addTask(tag: WendyTasks.addGroceryListItem, data: GroceryStoreItem(price: 4, name: "Bologna"))
             Wendy.shared.addTask(tag: WendyTasks.addGroceryListItem, data: GroceryStoreItem(price: 3, name: "American cheese"))
 
-            Wendy.shared.runTasks(onComplete: nil)
+            Task {
+                await Wendy.shared.runTasks()
+            }
         }
 
         func newTaskAdded(_ task: PendingTask) {}

--- a/app/ios/Source/WendyTaskRunner.swift
+++ b/app/ios/Source/WendyTaskRunner.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Wendy
 
-public class MyWendyTaskRunner: WendyTaskRunnerConcurrency {
+public class MyWendyTaskRunner: WendyTaskRunner {
     public func runTask(tag: String, data: Data?) async throws {
         // Sleep for 2 seconds to simulate a network request
         try await Task.sleep(nanoseconds: 500000000)

--- a/app/ios/project-spm.yml
+++ b/app/ios/project-spm.yml
@@ -3,8 +3,8 @@ include:
 
 packages:
   Wendy:
-    url: https://github.com/levibostian/Wendy-iOS.git
-    branch: latest # To verify that the latest changes are always compilable. Dont lock to a specific version. 
+    url: https://github.com/levibostian/Wendy-iOS.git 
+    path: ../../
 targets:
   App:
     dependencies:      


### PR DESCRIPTION
After a recent merge into main, compiling of apps broke. Makes sense because of a recent breaking change introduced in the code! However, apps should not fail after merge on main. It should always be passing. This commit changes from branch reference to local path reference when compiling apps.

commit-id:f4efed4b

---

**Stack**:
- #177 ⬅
- #180


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*