### PR TITLE
ci: fix semantic-release

### DIFF
--- a/.github/actions/setup-semantic-release/action.yml
+++ b/.github/actions/setup-semantic-release/action.yml
@@ -13,7 +13,7 @@ runs:
   - name: Install semantic-release plugins that we need for deployment of this project 
     run: >
       npm install       
-      conventional-changelog-conventionalcommits@7
+      conventional-changelog-conventionalcommits
       @semantic-release/github 
       @semantic-release/git 
       semantic-release-recovery@beta


### PR DESCRIPTION
semantic-release is failing it's deployments right now. I have fixed it in previous projects already so I knew how to fix it. 

Found help from: https://github.com/semantic-release/release-notes-generator/issues/660